### PR TITLE
Add support for optional add_requests parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: opencage
 Type: Package
 Title: Interface to the OpenCage API
 Version: 0.1.2
-Authors@R: c(person("Maëlle", "Salmon", email = "maelle.salmon@yahoo.se", role = c("aut", "cre")), person("Noam", "Ross", role = "ctb"), person("Julia", "Silge", role = c("ctb"), comment = "Julia Silge reviewed the package for rOpenSci, see https://github.com/ropensci/onboarding/issues/36."))
+Authors@R: c(person("Maëlle", "Salmon", email = "maelle.salmon@yahoo.se", role = c("aut", "cre")), person("Noam", "Ross", role = "ctb"), person("Julia", "Silge", role = c("ctb"), comment = "Julia Silge reviewed the package for rOpenSci, see https://github.com/ropensci/onboarding/issues/36."), person("Jake", "Russ", role = "ctb"))
 Description: Tool for accessing the OpenCage API, which provides forward
     geocoding (from placename to longitude and latitude) and reverse geocoding (from
     longitude and latitude to placename).

--- a/R/forward_geocoding.R
+++ b/R/forward_geocoding.R
@@ -27,7 +27,7 @@
   no_dedupe <- ifelse(is.null(no_dedupe), FALSE, no_dedupe)
   no_record <- ifelse(is.null(no_record), FALSE, no_record)
   abbrv <- ifelse(is.null(abbrv), FALSE, abbrv)
-  add_request <- ifelse(is.null(add_request), FALSE, add_request)
+  add_request <- ifelse(is.null(add_request), TRUE, add_request)
 
   # res
   temp <- opencage_get(query_par = list(q = placename,
@@ -68,7 +68,7 @@
 #' @param no_dedupe Logical (default FALSE), when TRUE the output will not be deduplicated.
 #' @param no_record Logical (default FALSE), when TRUE no log entry of the query is created at OpenCage.
 #' @param abbrv Logical (default FALSE), when TRUE addresses are abbreviated (e.g. C. instead of Calle)
-#' @param add_request Logical (default TRUE), when FALSE the request text is removed from the results data frame.
+#' @param add_request Logical (default TRUE), when FALSE the query text is removed from the results data frame.
 #'
 #' @details To get an API key to access OpenCage geocoding, register at \url{https://geocoder.opencagedata.com/pricing}. The free API key provides up to 2,500 calls a day. For ease of use, save your API key as an environment variable as described at \url{https://stat545-ubc.github.io/bit003_api-key-env-var.html}.
 #' Both functions of the package will conveniently look for your API key using \code{Sys.getenv("OPENCAGE_KEY")} so if your API key is an environment variable called "OPENCAGE_KEY" you don't need to input it manually.

--- a/R/forward_geocoding.R
+++ b/R/forward_geocoding.R
@@ -8,7 +8,7 @@
                              no_dedupe = FALSE,
                              no_record = FALSE,
                              abbrv = FALSE,
-                             add_request = FALSE){
+                             add_request = TRUE){
   # check arguments
   opencage_query_check(placename = placename,
                        key = key,

--- a/R/forward_geocoding.R
+++ b/R/forward_geocoding.R
@@ -68,7 +68,7 @@
 #' @param no_dedupe Logical (default FALSE), when TRUE the output will not be deduplicated.
 #' @param no_record Logical (default FALSE), when TRUE no log entry of the query is created at OpenCage.
 #' @param abbrv Logical (default FALSE), when TRUE addresses are abbreviated (e.g. C. instead of Calle)
-#' @param add_request Logical (default FALSE), when TRUE the request text is appended to the results data frame.
+#' @param add_request Logical (default TRUE), when FALSE the request text is removed from the results data frame.
 #'
 #' @details To get an API key to access OpenCage geocoding, register at \url{https://geocoder.opencagedata.com/pricing}. The free API key provides up to 2,500 calls a day. For ease of use, save your API key as an environment variable as described at \url{https://stat545-ubc.github.io/bit003_api-key-env-var.html}.
 #' Both functions of the package will conveniently look for your API key using \code{Sys.getenv("OPENCAGE_KEY")} so if your API key is an environment variable called "OPENCAGE_KEY" you don't need to input it manually.

--- a/R/forward_geocoding.R
+++ b/R/forward_geocoding.R
@@ -7,7 +7,8 @@
                              no_annotations = FALSE,
                              no_dedupe = FALSE,
                              no_record = FALSE,
-                             abbrv = FALSE){
+                             abbrv = FALSE,
+                             add_request = FALSE){
   # check arguments
   opencage_query_check(placename = placename,
                        key = key,
@@ -19,12 +20,14 @@
                        no_annotations = no_annotations,
                        no_dedupe = no_dedupe,
                        no_record = no_record,
-                       abbrv = abbrv)
+                       abbrv = abbrv,
+                       add_request = add_request)
 
   no_annotations <- ifelse(is.null(no_annotations), FALSE, no_annotations)
   no_dedupe <- ifelse(is.null(no_dedupe), FALSE, no_dedupe)
   no_record <- ifelse(is.null(no_record), FALSE, no_record)
   abbrv <- ifelse(is.null(abbrv), FALSE, abbrv)
+  add_request <- ifelse(is.null(add_request), FALSE, add_request)
 
   # res
   temp <- opencage_get(query_par = list(q = placename,
@@ -38,6 +41,7 @@
                                         no_dedupe = ifelse(no_dedupe == TRUE, 1, 0),
                                         no_record = ifelse(no_record == TRUE, 1, 0),
                                         abbrv = ifelse(abbrv == TRUE, 1, 0),
+                                        add_request = ifelse(add_request == TRUE, 1, 0),
                                         key = key))
 
   # check message
@@ -64,6 +68,7 @@
 #' @param no_dedupe Logical (default FALSE), when TRUE the output will not be deduplicated.
 #' @param no_record Logical (default FALSE), when TRUE no log entry of the query is created at OpenCage.
 #' @param abbrv Logical (default FALSE), when TRUE addresses are abbreviated (e.g. C. instead of Calle)
+#' @param add_request Logical (default FALSE), when TRUE the request text is appended to the results data frame.
 #'
 #' @details To get an API key to access OpenCage geocoding, register at \url{https://geocoder.opencagedata.com/pricing}. The free API key provides up to 2,500 calls a day. For ease of use, save your API key as an environment variable as described at \url{https://stat545-ubc.github.io/bit003_api-key-env-var.html}.
 #' Both functions of the package will conveniently look for your API key using \code{Sys.getenv("OPENCAGE_KEY")} so if your API key is an environment variable called "OPENCAGE_KEY" you don't need to input it manually.

--- a/R/reverse_geocoding.R
+++ b/R/reverse_geocoding.R
@@ -1,6 +1,6 @@
 .opencage_reverse <- function(latitude,
                               longitude,
-                              key=opencage_key(),
+                              key = opencage_key(),
                               bounds = NULL,
                               countrycode = NULL,
                               language = NULL,
@@ -50,9 +50,9 @@
                                          no_record =
                                            ifelse(no_record == TRUE, 1, 0),
                                         abbrv =
-                                          ifelse(abbrv == TRUE, 1, 0)),
+                                          ifelse(abbrv == TRUE, 1, 0),
                                          add_request =
-                                           ifelse(add_request == TRUE, 1, 0))
+                                           ifelse(add_request == TRUE, 1, 0)))
   # check message
   opencage_check(temp)
 

--- a/R/reverse_geocoding.R
+++ b/R/reverse_geocoding.R
@@ -9,8 +9,8 @@
                               no_annotations = FALSE,
                               no_dedupe = FALSE,
                               no_record = FALSE,
-                              abbrv = FALSE){
-
+                              abbrv = FALSE,
+                              add_request = TRUE){
 
   # check arguments
   opencage_query_check(latitude = latitude,
@@ -24,12 +24,14 @@
                        no_annotations = no_annotations,
                        no_dedupe = no_dedupe,
                        no_record = no_record,
-                       abbrv = abbrv)
+                       abbrv = abbrv,
+                       add_request = add_request)
 
   no_annotations <- ifelse(is.null(no_annotations), FALSE, no_annotations)
   no_dedupe <- ifelse(is.null(no_dedupe), FALSE, no_dedupe)
   no_record <- ifelse(is.null(no_record), FALSE, no_record)
   abbrv <- ifelse(is.null(abbrv), FALSE, abbrv)
+  add_request <- ifelse(is.null(add_request), TRUE, add_request)
 
 
   # res
@@ -48,7 +50,9 @@
                                          no_record =
                                            ifelse(no_record == TRUE, 1, 0),
                                         abbrv =
-                                          ifelse(abbrv == TRUE, 1, 0)))
+                                          ifelse(abbrv == TRUE, 1, 0)),
+                                         add_request =
+                                           ifelse(add_request == TRUE, 1, 0))
   # check message
   opencage_check(temp)
 
@@ -75,6 +79,7 @@
 #' @param no_dedupe Logical (default FALSE), when TRUE the output will not be deduplicated.
 #' @param no_record Logical (default FALSE), when TRUE no log entry of the query is created at OpenCage.
 #' @param abbrv Logical (default FALSE), when TRUE addresses are abbreviated (e.g. C. instead of Calle)
+#' @param add_request Logical (default TRUE), when FALSE the query text is removed from the results data frame.
 #'
 #' @details To get an API key to access OpenCage geocoding, register at \url{https://geocoder.opencagedata.com/pricing}. The free API key provides up to 2,500 calls a day. For ease of use, save your API key as an environment variable as described at \url{https://stat545-ubc.github.io/bit003_api-key-env-var.html}.
 #' Both functions of the package will conveniently look for your API key using \code{Sys.getenv("OPENCAGE_KEY")} so if your API key is an environment variable called "OPENCAGE_KEY" you don't need to input it manually.

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,6 +24,11 @@ opencage_parse <- function(req) {
       as.character(results$geometry.lat))
     results$geometry.lng <- as.numeric(
       as.character(results$geometry.lng))
+
+      # if requests exists in the api response add the query to results
+      if("request" %in% names(temp)) {
+        results$query <- as.character(temp$request$query)
+      }
   }
   else{
     results <- NULL
@@ -55,7 +60,7 @@ opencage_url <- function() {
   "http://api.opencagedata.com/geocode/v1/json/"
 }
 
-# get resultrs
+# get results
 opencage_get <- function(query_par){
   query_par <- Filter(Negate(is.null), query_par) # nolint
   if(!is.null(query_par$bounds)){
@@ -83,7 +88,8 @@ opencage_query_check <- function(latitude = NULL,
                                  min_confidence,
                                  no_annotations,
                                  no_dedupe,
-                                 no_record){
+                                 no_record,
+                                 add_request){
   # check latitude
   if(!is.null(latitude)){
     if (!dplyr::between(latitude, -90, 90)){
@@ -197,6 +203,12 @@ opencage_query_check <- function(latitude = NULL,
     }
   }
 
+  # check add_request
+  if(!is.null(add_request)){
+    if(!is.logical(add_request)){
+      stop(call. = FALSE, "add_request has to be a logical.")
+    }
+  }
 
 }
 

--- a/man/opencage_forward.Rd
+++ b/man/opencage_forward.Rd
@@ -7,7 +7,7 @@
 opencage_forward(placename, key = opencage_key(), bounds = NULL,
   countrycode = NULL, language = NULL, limit = 10,
   min_confidence = NULL, no_annotations = FALSE, no_dedupe = FALSE,
-  no_record = FALSE, abbrv = FALSE)
+  no_record = FALSE, abbrv = FALSE, add_request = TRUE)
 }
 \arguments{
 \item{placename}{Placename.}
@@ -31,6 +31,8 @@ opencage_forward(placename, key = opencage_key(), bounds = NULL,
 \item{no_record}{Logical (default FALSE), when TRUE no log entry of the query is created at OpenCage.}
 
 \item{abbrv}{Logical (default FALSE), when TRUE addresses are abbreviated (e.g. C. instead of Calle)}
+
+\item{add_request}{Logical (default TRUE), when FALSE the request text is removed from the results data frame.}
 }
 \value{
 A list with

--- a/man/opencage_forward.Rd
+++ b/man/opencage_forward.Rd
@@ -32,7 +32,7 @@ opencage_forward(placename, key = opencage_key(), bounds = NULL,
 
 \item{abbrv}{Logical (default FALSE), when TRUE addresses are abbreviated (e.g. C. instead of Calle)}
 
-\item{add_request}{Logical (default TRUE), when FALSE the request text is removed from the results data frame.}
+\item{add_request}{Logical (default TRUE), when FALSE the query text is removed from the results data frame.}
 }
 \value{
 A list with

--- a/man/opencage_reverse.Rd
+++ b/man/opencage_reverse.Rd
@@ -7,7 +7,7 @@
 opencage_reverse(latitude, longitude, key = opencage_key(), bounds = NULL,
   countrycode = NULL, language = NULL, limit = 10,
   min_confidence = NULL, no_annotations = FALSE, no_dedupe = FALSE,
-  no_record = FALSE, abbrv = FALSE)
+  no_record = FALSE, abbrv = FALSE, add_request = TRUE)
 }
 \arguments{
 \item{latitude}{Latitude.}
@@ -33,6 +33,8 @@ opencage_reverse(latitude, longitude, key = opencage_key(), bounds = NULL,
 \item{no_record}{Logical (default FALSE), when TRUE no log entry of the query is created at OpenCage.}
 
 \item{abbrv}{Logical (default FALSE), when TRUE addresses are abbreviated (e.g. C. instead of Calle)}
+
+\item{add_request}{Logical (default TRUE), when FALSE the query text is removed from the results data frame.}
 }
 \value{
 A list with

--- a/tests/testthat/test-opencage_query_check.R
+++ b/tests/testthat/test-opencage_query_check.R
@@ -140,3 +140,11 @@ test_that("opencage_query_check checks abbrv",{
                                 key = Sys.getenv("OPENCAGE_KEY")),
                "abbrv has to be a logical.")
 })
+
+test_that("opencage_query_check checks add_request",{
+  skip_on_cran()
+  expect_error(opencage_forward(placename = "Sarzeau",
+                                add_request = "yes",
+                                key = Sys.getenv("OPENCAGE_KEY")),
+               "add_request has to be a logical.")
+})

--- a/vignettes/opencage.Rmd
+++ b/vignettes/opencage.Rmd
@@ -130,3 +130,9 @@ Both functions have a parameter `no_record`. It is `FALSE` by default.
 ## Addresses
 
 They also have an `abbr` parameter, FALSE by default. When it is TRUE the addresses are abbreviated in the results, see more details in [this blog post](http://blog.opencagedata.com/post/160294347883/shrtr-pls).
+
+## Return query text
+
+The OpenCage API includes an optional `add_request` parameter that when set to 1 
+the query text is added to the response. This argument is set to TRUE by default,
+which allows for easy merging of the response data and the orignal query text.


### PR DESCRIPTION
I think returning the query to the results data frame is a desirable feature; see #21.

For now, I've added this as an argument and set the default to FALSE. But I think this is such a natural improvement for users that I would drop the argument entirely and always set this parameter to TRUE. 

If you agree, I will update the pull request.