### PR TITLE
lint & style fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ r:
 sudo: false
 cache: packages
 
-
 r_github_packages:
   - jimhester/covr
   - jimhester/lintr
@@ -18,3 +17,4 @@ notifications:
     on_failure: change
 after_success:
 - Rscript -e 'library(covr); codecov()'
+- Rscript -e 'library(lintr); lint_package()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Imports:
     tibble (>= 1.4.2)
 Suggests: 
     knitr (>= 1.19),
-    lintr (>= 1.0.2),
     rmarkdown (>= 1.8),
     testthat (>= 2.0.0)
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,7 +41,3 @@ The new features include:
 # opencage 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.
-
-
-
-

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -40,8 +40,10 @@ opencage_forward <-
            abbrv = FALSE,
            add_request = TRUE) {
     if (length(placename) > 1) {
-      stop(call. = FALSE,
-           "`opencage_forward` is not vectorised, use `oc_forward` instead.")
+      stop(
+        call. = FALSE,
+        "`opencage_forward` is not vectorised, use `oc_forward` instead."
+      )
     }
     lst <- oc_forward(
       placename = placename,
@@ -78,8 +80,10 @@ opencage_forward <-
 #'
 #' @examples
 #' \dontrun{
-#' opencage_reverse(latitude = 0, longitude = 0,
-#' limit = 2)
+#' opencage_reverse(
+#'   latitude = 0, longitude = 0,
+#'   limit = 2
+#' )
 #' }
 opencage_reverse <-
   function(latitude,
@@ -96,8 +100,10 @@ opencage_reverse <-
            abbrv = FALSE,
            add_request = TRUE) {
     if (length(latitude) > 1) {
-      stop(call. = FALSE,
-           "`opencage_reverse` is not vectorised, use `oc_reverse` instead.")
+      stop(
+        call. = FALSE,
+        "`opencage_reverse` is not vectorised, use `oc_reverse` instead."
+      )
     }
     lst <- oc_reverse(
       latitude = latitude,

--- a/R/oc_bbox.R
+++ b/R/oc_bbox.R
@@ -65,7 +65,7 @@ oc_bbox <- function(...) UseMethod("oc_bbox")
 
 #' @name oc_bbox
 #' @export
-oc_bbox.default <- function(xmin, ymin, xmax, ymax, ...) { # nolint
+oc_bbox.default <- function(xmin, ymin, xmax, ymax, ...) { # nolint - see lintr issue #223
   bbox <- function(xmin, ymin, xmax, ymax) {
     oc_check_bbox(xmin = xmin, ymin = ymin, xmax = xmax, ymax = ymax)
     structure(
@@ -90,7 +90,7 @@ oc_bbox.default <- function(xmin, ymin, xmax, ymax, ...) { # nolint
 
 #' @name oc_bbox
 #' @export
-oc_bbox.data.frame <- function(data, xmin, ymin, xmax, ymax, ...) { # nolint
+oc_bbox.data.frame <- function(data, xmin, ymin, xmax, ymax, ...) { # nolint - see lintr issue #223
   xmin <- data[[deparse(substitute(xmin))]]
   ymin <- data[[deparse(substitute(ymin))]]
   xmax <- data[[deparse(substitute(xmax))]]
@@ -100,7 +100,7 @@ oc_bbox.data.frame <- function(data, xmin, ymin, xmax, ymax, ...) { # nolint
 
 #' @name oc_bbox
 #' @export
-oc_bbox.bbox <- function(bbox, ...) { # nolint
+oc_bbox.bbox <- function(bbox, ...) { # nolint - see lintr issue #223
   # check coordinate reference system (and be lenient if NA_crs_)
   crs <- attr(bbox, "crs")[["epsg"]]
   if (!is.na(crs) && crs != 4326L) {

--- a/R/oc_bbox.R
+++ b/R/oc_bbox.R
@@ -65,7 +65,7 @@ oc_bbox <- function(...) UseMethod("oc_bbox")
 
 #' @name oc_bbox
 #' @export
-oc_bbox.default <- function(xmin, ymin, xmax, ymax, ...) {
+oc_bbox.default <- function(xmin, ymin, xmax, ymax, ...) { # nolint
   bbox <- function(xmin, ymin, xmax, ymax) {
     oc_check_bbox(xmin = xmin, ymin = ymin, xmax = xmax, ymax = ymax)
     structure(
@@ -90,7 +90,7 @@ oc_bbox.default <- function(xmin, ymin, xmax, ymax, ...) {
 
 #' @name oc_bbox
 #' @export
-oc_bbox.data.frame <- function(data, xmin, ymin, xmax, ymax, ...) {
+oc_bbox.data.frame <- function(data, xmin, ymin, xmax, ymax, ...) { # nolint
   xmin <- data[[deparse(substitute(xmin))]]
   ymin <- data[[deparse(substitute(ymin))]]
   xmax <- data[[deparse(substitute(xmax))]]
@@ -100,7 +100,7 @@ oc_bbox.data.frame <- function(data, xmin, ymin, xmax, ymax, ...) {
 
 #' @name oc_bbox
 #' @export
-oc_bbox.bbox <- function(bbox, ...) {
+oc_bbox.bbox <- function(bbox, ...) { # nolint
   # check coordinate reference system (and be lenient if NA_crs_)
   crs <- attr(bbox, "crs")[["epsg"]]
   if (!is.na(crs) && crs != 4326L) {

--- a/R/oc_bbox.R
+++ b/R/oc_bbox.R
@@ -10,8 +10,9 @@
 #'   \code{northeast_lng}, \code{east}, or \code{right}).
 #' @param ymax Maximum latitude (also known as \code{max lat},
 #'   \code{northeast_lat}, \code{north}, or \code{top}).
-#' @param data A \code{data.frame} containing at least 4 columns with \code{xmin},
-#'   \code{ymin}, \code{xmax}, and \code{ymax} values, respectively.
+#' @param data A \code{data.frame} containing at least 4 columns with
+#'   \code{xmin}, \code{ymin}, \code{xmax}, and \code{ymax} values,
+#'   respectively.
 #' @param bbox A \code{bbox} object, see \code{sf::st_bbox}.
 #' @param ... Ignored.
 #'
@@ -50,7 +51,7 @@
 #'    )
 #'
 #' # create bbox list from a simple features bbox
-#' if (requireNamespace("sf", quietly = TRUE)){
+#' if (requireNamespace("sf", quietly = TRUE)) {
 #'   library(sf)
 #'   bbox <- st_bbox(c(xmin = 16.1, xmax = 16.6, ymax = 48.6, ymin = 47.9),
 #'     crs = 4326)
@@ -60,7 +61,7 @@ oc_bbox <- function(...) UseMethod("oc_bbox")
 
 #' @name oc_bbox
 #' @export
-oc_bbox.default <- function (xmin, ymin, xmax, ymax, ...){
+oc_bbox.default <- function(xmin, ymin, xmax, ymax, ...) {
   bbox <- function(xmin, ymin, xmax, ymax) {
     oc_check_bbox(xmin = xmin, ymin = ymin, xmax = xmax, ymax = ymax)
     structure(
@@ -85,7 +86,7 @@ oc_bbox.default <- function (xmin, ymin, xmax, ymax, ...){
 
 #' @name oc_bbox
 #' @export
-oc_bbox.data.frame <- function (data, xmin, ymin, xmax, ymax, ...){
+oc_bbox.data.frame <- function(data, xmin, ymin, xmax, ymax, ...) {
   xmin <- data[[deparse(substitute(xmin))]]
   ymin <- data[[deparse(substitute(ymin))]]
   xmax <- data[[deparse(substitute(xmax))]]
@@ -95,7 +96,7 @@ oc_bbox.data.frame <- function (data, xmin, ymin, xmax, ymax, ...){
 
 #' @name oc_bbox
 #' @export
-oc_bbox.bbox <- function (bbox, ...) {
+oc_bbox.bbox <- function(bbox, ...) {
   # check coordinate reference system (and be lenient if NA_crs_)
   crs <- attr(bbox, "crs")[["epsg"]]
   if (!is.na(crs) && crs != 4326L) {

--- a/R/oc_bbox.R
+++ b/R/oc_bbox.R
@@ -23,13 +23,13 @@
 #' oc_bbox(-5.63160, 51.280430, 0.278970, 51.683979)
 #'
 #' xdf <-
-#' data.frame(
-#'   place = c("Hamburg", "Hamburg"),
-#'   northeast_lat = c(54.0276817, 42.7397729),
-#'   northeast_lng = c(10.3252805, -78.812825),
-#'   southwest_lat = c(53.3951118, 42.7091669),
-#'   southwest_lng = c(8.1053284, -78.860521)
-#' )
+#'   data.frame(
+#'     place = c("Hamburg", "Hamburg"),
+#'     northeast_lat = c(54.0276817, 42.7397729),
+#'     northeast_lng = c(10.3252805, -78.812825),
+#'     southwest_lat = c(53.3951118, 42.7091669),
+#'     southwest_lng = c(8.1053284, -78.860521)
+#'   )
 #' oc_bbox(
 #'   xdf,
 #'   southwest_lng,
@@ -41,22 +41,26 @@
 #' # create bbox list column with dplyr
 #' library(dplyr)
 #' xdf %>%
-#'   mutate(bbox =
-#'     oc_bbox(
-#'       southwest_lng,
-#'       southwest_lat,
-#'       northeast_lng,
-#'       northeast_lat
-#'      )
-#'    )
+#'   mutate(
+#'     bbox =
+#'       oc_bbox(
+#'         southwest_lng,
+#'         southwest_lat,
+#'         northeast_lng,
+#'         northeast_lat
+#'       )
+#'   )
 #'
 #' # create bbox list from a simple features bbox
 #' if (requireNamespace("sf", quietly = TRUE)) {
 #'   library(sf)
 #'   bbox <- st_bbox(c(xmin = 16.1, xmax = 16.6, ymax = 48.6, ymin = 47.9),
-#'     crs = 4326)
+#'     crs = 4326
+#'   )
 #'   oc_bbox(bbox)
-#' }}
+#' }
+#' }
+#'
 oc_bbox <- function(...) UseMethod("oc_bbox")
 
 #' @name oc_bbox

--- a/R/oc_check_query.R
+++ b/R/oc_check_query.R
@@ -82,7 +82,8 @@ oc_check_query <-
     if (!is.null(latitude)) {
       if (!(dplyr::between(latitude, -90, 90))) {
         stop("Every `latitude` must be numeric and between -90 and 90.",
-             call. = FALSE)
+          call. = FALSE
+        )
       }
     }
 
@@ -90,7 +91,8 @@ oc_check_query <-
     if (!is.null(longitude)) {
       if (!(dplyr::between(longitude, -180, 180))) {
         stop("Every `longitude` must be numeric and between -180 and 180.",
-             call. = FALSE)
+          call. = FALSE
+        )
       }
     }
 
@@ -118,8 +120,9 @@ oc_check_query <-
     if (!is.null(countrycode)) {
       if (!(all(toupper(unlist(countrycode)) %in% countrycodes$code))) {
         stop("Every `countrycode` must be valid. ",
-             "See `data('countrycodes')` for valid values.",
-             call. = FALSE)
+          "See `data('countrycodes')` for valid values.",
+          call. = FALSE
+        )
       }
     }
 
@@ -128,16 +131,18 @@ oc_check_query <-
       lang <- strsplit(language, "-")[[1]]
       if (!(lang[1] %in% languagecodes$code)) {
         stop("Every `language` abbreviation must be valid. ",
-             "The first part, the languagecode, is incorrect. ",
-             "See `data('languagecodes')` for valid values.",
-             call. = FALSE)
+          "The first part, the languagecode, is incorrect. ",
+          "See `data('languagecodes')` for valid values.",
+          call. = FALSE
+        )
       }
       if (length(lang) > 1) {
         if (!(lang[2] %in% countrycodes$code)) {
           stop("Every `language` abbreviation must be valid. ",
-               "The second part, the countrycode, is incorrect. ",
-               "See `data('countrycodes')` for valid values.",
-               call. = FALSE)
+            "The second part, the countrycode, is incorrect. ",
+            "See `data('countrycodes')` for valid values.",
+            call. = FALSE
+          )
         }
       }
     }

--- a/R/oc_check_query.R
+++ b/R/oc_check_query.R
@@ -8,7 +8,6 @@
 #'
 #' @keywords internal
 
-
 oc_check_query <-
   function(
     placename = NULL,

--- a/R/oc_forward.R
+++ b/R/oc_forward.R
@@ -2,7 +2,7 @@
 #'
 #' Forward geocoding, from placename to latitude and longitude tuple(s).
 #'
-# nolint start
+# nolint start - link longer than 80 chars
 #' @param placename A character vector with the placename(s) to be geocoded.
 #'   Required. If the placename(s) is/are address(es), see
 #'   \href{https://github.com/OpenCageData/opencagedata-misc-docs/blob/master/query-formatting.md}{OpenCage's

--- a/R/oc_forward.R
+++ b/R/oc_forward.R
@@ -2,10 +2,12 @@
 #'
 #' Forward geocoding, from placename to latitude and longitude tuple(s).
 #'
+# nolint start
 #' @param placename A character vector with the placename(s) to be geocoded.
 #'   Required. If the placename(s) is/are address(es), see
 #'   \href{https://github.com/OpenCageData/opencagedata-misc-docs/blob/master/query-formatting.md}{OpenCage's
 #'    instructions} on how to format addresses for forward geocoding best.
+# nolint end
 #' @param return A character vector of length one indicating the return value of
 #'   the function, either a list of tibbles (\code{df_list}, the default), a
 #'   JSON list (\code{json_list}), a GeoJSON list (\code{geojson_list}), or the
@@ -171,6 +173,7 @@ oc_forward_df <-
 
     placename <- data[[deparse(substitute(placename))]]
 
+    # nolint start
     bounds_ <- eval(substitute(alist(bounds)))[[1]]
     if (is.symbol(bounds_)) {
       bounds_ <- data[[deparse(bounds_)]]
@@ -242,6 +245,7 @@ oc_forward_df <-
       abbrv <- eval(abbrv_)
     }
     if (!is.null(abbrv)) abbrv <- as.list(abbrv)
+    # nolint end
 
     output <- match.arg(output)
 

--- a/R/oc_process.R
+++ b/R/oc_process.R
@@ -151,6 +151,6 @@ oc_process <-
     # check status message
     oc_check_status(res_env, res_text)
 
-    # done!
+    # format output
     oc_format(res_text = res_text, return = return, query = query)
     }

--- a/R/oc_process.R
+++ b/R/oc_process.R
@@ -68,12 +68,14 @@ oc_process <-
     # prevent obscure warning message from pwalk if length(arglist) == 0
     stopifnot(length(arglist) >= 1)
 
-    purrr::pmap(.l = arglist,
-                .f = .oc_process,
-                return = return,
-                key = key,
-                no_record = no_record,
-                pb = pb)
+    purrr::pmap(
+      .l = arglist,
+      .f = .oc_process,
+      return = return,
+      key = key,
+      no_record = no_record,
+      pb = pb
+    )
   }
 
 .oc_process <-

--- a/R/oc_reverse.R
+++ b/R/oc_reverse.R
@@ -27,7 +27,7 @@
 #' \dontrun{
 #' oc_reverse(latitude = 0, longitude = 0)
 #' }
-
+#'
 oc_reverse <-
   function(latitude,
            longitude,

--- a/R/oc_reverse.R
+++ b/R/oc_reverse.R
@@ -112,6 +112,7 @@ oc_reverse_df <-
     latitude <- data[[substitute(latitude)]]
     longitude <- data[[substitute(longitude)]]
 
+    # nolint start
     language_ <- eval(substitute(alist(language)))[[1]]
     if (is.symbol(language_)) {
       language_ <- data[[deparse(language_)]]
@@ -161,6 +162,7 @@ oc_reverse_df <-
       abbrv <- eval(abbrv_)
     }
     if (!is.null(abbrv)) abbrv <- as.list(abbrv)
+    # nolint end
 
     output <- match.arg(output)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -56,7 +56,7 @@ oc_format <- function(res_text, return, query) {
 oc_build_url <- function(query_par, endpoint) {
   query_par <- purrr::compact(query_par) # nolint
 
-  if ("countrycode" %in% names(query_par)){
+  if ("countrycode" %in% names(query_par)) {
     query_par$countrycode <-
       tolower(paste(query_par$countrycode, collapse = ","))
   }
@@ -104,18 +104,19 @@ oc_get_limited <-
 oc_get_memoise <- memoise::memoise(oc_get_limited)
 
 # initialise progress bar
-oc_init_progress <- function(vec){
-    progress::progress_bar$new(
-      format =
-        "Retrieving results from OpenCage [:spin] :percent ETA: :eta",
-      total = length(vec),
-      clear = FALSE,
-      width = 60)
+oc_init_progress <- function(vec) {
+  progress::progress_bar$new(
+    format =
+      "Retrieving results from OpenCage [:spin] :percent ETA: :eta",
+    total = length(vec),
+    clear = FALSE,
+    width = 60
+  )
 }
 
 # format to "old" style (version <= 0.1.4)
 # for opencage_forward, opencage_reverse
-opencage_format <- function(lst){
+opencage_format <- function(lst) {
   no_results <- lst[["total_results"]]
   if (no_results > 0) {
     results <- lapply(lst[["results"]], unlist)

--- a/man/oc_bbox.Rd
+++ b/man/oc_bbox.Rd
@@ -46,13 +46,13 @@ Create a bounding box list for opencage queries.
 oc_bbox(-5.63160, 51.280430, 0.278970, 51.683979)
 
 xdf <-
-data.frame(
-  place = c("Hamburg", "Hamburg"),
-  northeast_lat = c(54.0276817, 42.7397729),
-  northeast_lng = c(10.3252805, -78.812825),
-  southwest_lat = c(53.3951118, 42.7091669),
-  southwest_lng = c(8.1053284, -78.860521)
-)
+  data.frame(
+    place = c("Hamburg", "Hamburg"),
+    northeast_lat = c(54.0276817, 42.7397729),
+    northeast_lng = c(10.3252805, -78.812825),
+    southwest_lat = c(53.3951118, 42.7091669),
+    southwest_lng = c(8.1053284, -78.860521)
+  )
 oc_bbox(
   xdf,
   southwest_lng,
@@ -64,20 +64,24 @@ oc_bbox(
 # create bbox list column with dplyr
 library(dplyr)
 xdf \%>\%
-  mutate(bbox =
-    oc_bbox(
-      southwest_lng,
-      southwest_lat,
-      northeast_lng,
-      northeast_lat
-     )
-   )
+  mutate(
+    bbox =
+      oc_bbox(
+        southwest_lng,
+        southwest_lat,
+        northeast_lng,
+        northeast_lat
+      )
+  )
 
 # create bbox list from a simple features bbox
 if (requireNamespace("sf", quietly = TRUE)) {
   library(sf)
   bbox <- st_bbox(c(xmin = 16.1, xmax = 16.6, ymax = 48.6, ymin = 47.9),
-    crs = 4326)
+    crs = 4326
+  )
   oc_bbox(bbox)
-}}
+}
+}
+
 }

--- a/man/oc_bbox.Rd
+++ b/man/oc_bbox.Rd
@@ -30,8 +30,9 @@ oc_bbox(...)
 \item{ymax}{Maximum latitude (also known as \code{max lat},
 \code{northeast_lat}, \code{north}, or \code{top}).}
 
-\item{data}{A \code{data.frame} containing at least 4 columns with \code{xmin},
-\code{ymin}, \code{xmax}, and \code{ymax} values, respectively.}
+\item{data}{A \code{data.frame} containing at least 4 columns with
+\code{xmin}, \code{ymin}, \code{xmax}, and \code{ymax} values,
+respectively.}
 
 \item{bbox}{A \code{bbox} object, see \code{sf::st_bbox}.}
 }
@@ -73,7 +74,7 @@ xdf \%>\%
    )
 
 # create bbox list from a simple features bbox
-if (requireNamespace("sf", quietly = TRUE)){
+if (requireNamespace("sf", quietly = TRUE)) {
   library(sf)
   bbox <- st_bbox(c(xmin = 16.1, xmax = 16.6, ymax = 48.6, ymin = 47.9),
     crs = 4326)

--- a/man/oc_reverse.Rd
+++ b/man/oc_reverse.Rd
@@ -97,6 +97,7 @@ except \code{key}, \code{return}, and \code{no_record}.
 \dontrun{
 oc_reverse(latitude = 0, longitude = 0)
 }
+
 }
 \seealso{
 \code{\link{oc_forward}} for reverse geocoding, and the

--- a/man/opencage_reverse.Rd
+++ b/man/opencage_reverse.Rd
@@ -78,7 +78,9 @@ Reverse geocoding, from latitude and longitude to placename(s).
 }
 \examples{
 \dontrun{
-opencage_reverse(latitude = 0, longitude = 0,
-limit = 2)
+opencage_reverse(
+  latitude = 0, longitude = 0,
+  limit = 2
+)
 }
 }

--- a/tests/testthat/test-lintr.R
+++ b/tests/testthat/test-lintr.R
@@ -1,8 +1,0 @@
-library("opencage")
-context("lintr")
-if (requireNamespace("lintr", quietly = TRUE)) {
-  context("lints")
-  test_that("Package Code Style", {
-    lintr::expect_lint_free()
-  })
-}

--- a/tests/testthat/test-oc_bbox.R
+++ b/tests/testthat/test-oc_bbox.R
@@ -20,7 +20,7 @@ test_that("oc_bbox works with numeric", {
     c(
       xmin = -5.6,
       ymin = 51.2,
-      xmax =  0.2,
+      xmax = 0.2,
       ymax = 51.6
     )
   )
@@ -29,18 +29,19 @@ test_that("oc_bbox works with numeric", {
 test_that("oc_bbox works with data.frame", {
   xdf <-
     data.frame(
-      northeast_lat = c(54.0,  42.73),
+      northeast_lat = c(54.0, 42.73),
       northeast_lng = c(10.3, -78.81),
-      southwest_lat = c(53.3,  42.70),
+      southwest_lat = c(53.3, 42.70),
       southwest_lng = c(8.1, -78.86)
     )
 
   bbox2 <-
-    oc_bbox(xdf,
-            southwest_lng,
-            southwest_lat,
-            northeast_lng,
-            northeast_lat
+    oc_bbox(
+      xdf,
+      southwest_lng,
+      southwest_lat,
+      northeast_lng,
+      northeast_lat
     )
   expect_type(
     bbox2,
@@ -57,7 +58,7 @@ test_that("oc_bbox works with data.frame", {
   expect_equal(
     unlist(bbox2[1]),
     c(
-      xmin =  8.1,
+      xmin = 8.1,
       ymin = 53.3,
       xmax = 10.3,
       ymax = 54.0
@@ -67,9 +68,9 @@ test_that("oc_bbox works with data.frame", {
     unlist(bbox2[2]),
     c(
       xmin = -78.86,
-      ymin =  42.70,
+      ymin = 42.70,
       xmax = -78.81,
-      ymax =  42.73
+      ymax = 42.73
     )
   )
 })
@@ -83,7 +84,8 @@ test_that("oc_bbox works with simple features bbox", {
       ymax = 48.6,
       ymin = 47.9
     ),
-    crs = 4326)
+    crs = 4326
+    )
   ocbbox <- oc_bbox(sfbbox)
 
   expect_type(

--- a/tests/testthat/test-oc_bbox.R
+++ b/tests/testthat/test-oc_bbox.R
@@ -32,7 +32,7 @@ test_that("oc_bbox works with data.frame", {
       northeast_lat = c(54.0,  42.73),
       northeast_lng = c(10.3, -78.81),
       southwest_lat = c(53.3,  42.70),
-      southwest_lng = c( 8.1, -78.86)
+      southwest_lng = c(8.1, -78.86)
     )
 
   bbox2 <-

--- a/tests/testthat/test-oc_build_url.R
+++ b/tests/testthat/test-oc_build_url.R
@@ -6,6 +6,6 @@ test_that("oc_build_url returns a string", {
       query_par = list(placename = "Haarlem"),
       endpoint = "json"
     ),
-    "character")
-  }
-)
+    "character"
+  )
+})

--- a/tests/testthat/test-oc_check_query.R
+++ b/tests/testthat/test-oc_check_query.R
@@ -73,18 +73,18 @@ test_that("oc_check_query checks countrycode", {
 
 test_that("oc_check_query ok with lower case countrycode", {
   expect_silent(
-   oc_check_query(
+    oc_check_query(
       placename = "Sarzeau",
       key = "32randomlettersanddigits12345678",
       countrycode = "fr"
     )
-   )
+  )
   expect_silent(
-   oc_check_query(
-     placename = "Sarzeau",
-     key = "32randomlettersanddigits12345678",
-     countrycode = "FR"
-   )
+    oc_check_query(
+      placename = "Sarzeau",
+      key = "32randomlettersanddigits12345678",
+      countrycode = "FR"
+    )
   )
 })
 

--- a/tests/testthat/test-oc_check_status.R
+++ b/tests/testthat/test-oc_check_status.R
@@ -1,7 +1,7 @@
 library("opencage")
 context("oc_check_status")
 # keys from https://opencagedata.com/api#codes or
-# https://github.com/OpenCageData/opencagedata-misc-docs/blob/master/library-guidelines.md nolint
+# https://github.com/OpenCageData/opencagedata-misc-docs/blob/master/library-guidelines.md # nolint
 key_402 <- "4372eff77b8343cebfc843eb4da4ddc4" # always returns a 402 responce
 key_403 <- "2e10e5e828262eb243ec0b54681d699a" # always returns a 403 responce
 

--- a/tests/testthat/test-oc_config.R
+++ b/tests/testthat/test-oc_config.R
@@ -21,5 +21,4 @@ test_that("oc_config updates rate limit of oc_get_limit", {
   rps <- 3L
   oc_config(max_rate_per_sec = rps)
   expect_gt(timer(oc_get_limited_test(rps + 1)), 1)
-  }
-)
+})

--- a/tests/testthat/test-oc_process.R
+++ b/tests/testthat/test-oc_process.R
@@ -3,26 +3,33 @@ context("oc_process")
 
 test_that("oc_process creates meaningful URLs for single query.", {
   res <-
-    oc_process(placename = "Paris",
-               return = "url_only",
-               key = NULL)
+    oc_process(
+      placename = "Paris",
+      return = "url_only",
+      key = NULL
+    )
   expect_is(res, "list")
   expect_is(unlist(res), "character")
   expect_match(res[[1]], "q=Paris", fixed = TRUE)
 
   res <-
-    oc_process(placename = "Islington, London",
-               return = "url_only",
-               key = NULL)
+    oc_process(
+      placename = "Islington, London",
+      return = "url_only",
+      key = NULL
+    )
   expect_match(res[[1]], "q=Islington%2C%20London", fixed = TRUE)
 
   res <-
-    oc_process(placename = "Triererstr 15, 99423 Weimar, Deutschland",
-               return = "url_only",
-               key = NULL)
+    oc_process(
+      placename = "Triererstr 15, 99423 Weimar, Deutschland",
+      return = "url_only",
+      key = NULL
+    )
   expect_match(res[[1]],
-               "q=Triererstr%2015%2C%2099423%20Weimar%2C%20Deutschland",
-               fixed = TRUE)
+    "q=Triererstr%2015%2C%2099423%20Weimar%2C%20Deutschland",
+    fixed = TRUE
+  )
 
   res <-
     oc_process(
@@ -61,7 +68,7 @@ test_that("oc_process creates meaningful URLs for multiple queries.", {
 
 test_that("oc_process deals well with res being NULL", {
   skip_on_cran()
-    res <- oc_process(
+  res <- oc_process(
     placename = "thiswillgetmenoreswhichisgood",
     key = Sys.getenv("OPENCAGE_KEY"),
     limit = 2,

--- a/tests/testthat/test-opencage_forward.R
+++ b/tests/testthat/test-opencage_forward.R
@@ -54,8 +54,10 @@ test_that("opencage_forward/opencage_reverse return what they should
   expect_is(results[["total_results"]], "integer")
   expect_is(results[["time_stamp"]], "POSIXct")
   expect_equal(length(results), 4)
-  expect_equal(sum(grepl("annotation",
-                         names(results[["results"]]))), 0)
+  expect_equal(sum(grepl(
+    "annotation",
+    names(results[["results"]])
+  )), 0)
   expect_true(dplyr::between(nrow(results[["results"]]), 1, 2))
 
   results <- opencage_reverse(
@@ -72,8 +74,10 @@ test_that("opencage_forward/opencage_reverse return what they should
   expect_is(results[["total_results"]], "integer")
   expect_is(results[["time_stamp"]], "POSIXct")
   expect_equal(length(results), 4)
-  expect_equal(sum(grepl("annotation",
-                         names(results[["results"]]))), 0)
+  expect_equal(sum(grepl(
+    "annotation",
+    names(results[["results"]])
+  )), 0)
   expect_true(dplyr::between(nrow(results[["results"]]), 1, 2))
 })
 


### PR DESCRIPTION
This PR fixes some style issues, most of which the lintr-bot complained about. The reason I missed these seems to be that I had the CRAN version of lintr installed, while lintr-bot uses the current master from Github.

@maelle: Should we switch to [travis-after_success style lintr checks](https://github.com/jimhester/lintr#non-failing-lints) instead of testthat? This would speed up local tests, remove the `Suggests` dependency on lintr and is the recommended setup. 