### PR TITLE
Cleanup tests #73

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
 Suggests: 
     knitr (>= 1.19),
     rmarkdown (>= 1.8),
-    testthat (>= 2.0.0)
+    testthat (>= 2.1.0)
 VignetteBuilder: knitr
 Encoding: UTF-8
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,8 @@ Imports:
 Suggests: 
     knitr (>= 1.19),
     rmarkdown (>= 1.8),
-    testthat (>= 2.1.0)
+    testthat (>= 2.1.0),
+    sf
 VignetteBuilder: knitr
 Encoding: UTF-8
 Language: en-GB

--- a/tests/testthat/test-oc_bbox.R
+++ b/tests/testthat/test-oc_bbox.R
@@ -77,7 +77,7 @@ test_that("oc_bbox works with data.frame", {
 test_that("oc_bbox works with simple features bbox", {
   skip_if_not_installed("sf")
   sfbbox <-
-    st_bbox(c(
+    sf::st_bbox(c(
       xmin = 16.1,
       xmax = 16.6,
       ymax = 48.6,

--- a/tests/testthat/test-oc_bbox.R
+++ b/tests/testthat/test-oc_bbox.R
@@ -1,5 +1,4 @@
-library("opencage")
-context("oc_bbox")
+## Test oc_bbox ##
 
 test_that("oc_bbox works with numeric", {
   bbox1 <- oc_bbox(-5.6, 51.2, 0.2, 51.6)
@@ -78,7 +77,7 @@ test_that("oc_bbox works with data.frame", {
 test_that("oc_bbox works with simple features bbox", {
   skip_if_not_installed("sf")
   sfbbox <-
-    sf::st_bbox(c(
+    st_bbox(c(
       xmin = 16.1,
       xmax = 16.6,
       ymax = 48.6,

--- a/tests/testthat/test-oc_build_url.R
+++ b/tests/testthat/test-oc_build_url.R
@@ -1,7 +1,7 @@
-library("opencage")
-context("oc_build_url")
+## Test oc_build_url ##
+
 test_that("oc_build_url returns a string", {
-  expect_is(
+  expect_type(
     oc_build_url(
       query_par = list(placename = "Haarlem"),
       endpoint = "json"

--- a/tests/testthat/test-oc_check_bbox.R
+++ b/tests/testthat/test-oc_check_bbox.R
@@ -1,5 +1,4 @@
-library("opencage")
-context("oc_check_bbox")
+# Test checks for oc_bbox ##
 
 test_that("oc_check_bbox checks bbox", {
   expect_error(

--- a/tests/testthat/test-oc_check_query.R
+++ b/tests/testthat/test-oc_check_query.R
@@ -1,5 +1,4 @@
-library("opencage")
-context("oc_check_query")
+## Test oc_check_query: error messages ##
 
 test_that("oc_check_query checks placename", {
   expect_error(

--- a/tests/testthat/test-oc_check_status.R
+++ b/tests/testthat/test-oc_check_status.R
@@ -1,5 +1,5 @@
-library("opencage")
-context("oc_check_status")
+## Test oc_check_status ##
+
 # keys from https://opencagedata.com/api#codes or
 # https://github.com/OpenCageData/opencagedata-misc-docs/blob/master/library-guidelines.md # nolint
 key_402 <- "4372eff77b8343cebfc843eb4da4ddc4" # always returns a 402 responce
@@ -7,6 +7,8 @@ key_403 <- "2e10e5e828262eb243ec0b54681d699a" # always returns a 403 responce
 
 test_that("oc_check_status returns 402 error if quota exceeded", {
   skip_on_cran()
+  skip_if_offline()
+
   expect_error(
     oc_reverse(
       latitude = 0, longitude = 0,
@@ -18,6 +20,8 @@ test_that("oc_check_status returns 402 error if quota exceeded", {
 
 test_that("oc_check_status returns 403 error if key is blocked", {
   skip_on_cran()
+  skip_if_offline()
+
   expect_error(
     oc_reverse(
       latitude = 0, longitude = 0,
@@ -29,6 +33,8 @@ test_that("oc_check_status returns 403 error if key is blocked", {
 
 test_that("oc_check_status returns 401 error if key is invalid", {
   skip_on_cran()
+  skip_if_offline()
+
   expect_error(
     oc_reverse(
       latitude = 0, longitude = 0,
@@ -41,6 +47,8 @@ test_that("oc_check_status returns 401 error if key is invalid", {
 # Shouldn't happen since we oc_check coordinates
 test_that("oc_check_status returns 400 error if coordinates are invalid", {
   skip_on_cran()
+  skip_if_offline()
+
   expect_error(
     oc_process(latitude = 280, longitude = 0, return = "json_list"),
     "HTTP failure: 400"

--- a/tests/testthat/test-oc_config.R
+++ b/tests/testthat/test-oc_config.R
@@ -1,5 +1,4 @@
-library("opencage")
-context("oc_config")
+## Test oc_config ##
 
 timer <- function(expr) {
   system.time(expr)[["elapsed"]]
@@ -15,9 +14,11 @@ oc_get_limited_test <- function(reps) {
 test_that("oc_config updates rate limit of oc_get_limit", {
   skip_on_cran()
   skip_if_offline()
+
   rps <- 5L
   oc_config(max_rate_per_sec = rps)
   expect_gt(timer(oc_get_limited_test(rps + 1)), 1)
+
   rps <- 3L
   oc_config(max_rate_per_sec = rps)
   expect_gt(timer(oc_get_limited_test(rps + 1)), 1)

--- a/tests/testthat/test-oc_forward.R
+++ b/tests/testthat/test-oc_forward.R
@@ -1,0 +1,127 @@
+## Test oc_forward functions ##
+
+library(tibble)
+locations <- c("Nantes", "Hamburg", "Los Angeles")
+df <- tibble(id = 1:3, loc = locations)
+df2 <- add_column(df,
+                  bounds = oc_bbox(xmin = c(-72, -80, -76),
+                                   ymin = c(45, 42, 8),
+                                   xmax = c(-70, -78, -74),
+                                   ymax = c(46, 43, 10)),
+                  countrycode = c("ca", "us", "co"),
+                  language = c("de", "fr", "es"),
+                  limit = 1:3,
+                  confidence = c(7, 5, 3),
+                  annotation = c(FALSE, TRUE, TRUE),
+                  abbrv = c(FALSE, FALSE, TRUE))
+
+
+# oc_forward --------------------------------------------------------------
+
+test_that("oc_forward works", {
+  skip_on_cran()
+  skip_if_offline()
+
+  res1 <- oc_forward(locations)
+  expect_type(res1, "list")
+  expect_equal(length(res1), 3)
+  expect_s3_class(res1[[1]], c("tbl_df", "tbl", "data.frame"))
+})
+
+test_that("oc_forward returns correct type", {
+  skip_on_cran()
+  skip_if_offline()
+
+  # json_list
+  res2 <- oc_forward(locations, return = "json_list")
+  expect_type(res2, "list")
+  expect_equal(length(res2), 3)
+  expect_type(res2[[1]], "list")
+
+  # geojson_list
+  res3 <- oc_forward(locations, return = "geojson_list")
+  expect_type(res3, "list")
+  expect_equal(length(res3), 3)
+  expect_s3_class(res3[[1]], "geo_list")
+})
+
+
+# oc_forward_df -----------------------------------------------------------
+
+test_that("oc_forward_df works", {
+  skip_on_cran()
+  skip_if_offline()
+
+  tbl1 <- oc_forward_df(df, loc)
+  expect_s3_class(tbl1, c("tbl_df", "tbl", "data.frame"))
+  expect_equal(nrow(tbl1), 3)
+
+  tbl2 <- oc_forward_df(tibble(loc = "Nantes"), loc)
+  expect_s3_class(tbl2, c("tbl_df", "tbl", "data.frame"))
+  expect_equal(nrow(tbl2), 1)
+
+  # Error with no placename
+  expect_error(oc_forward_df(df), "`placename` must be provided.")
+  expect_error(oc_forward_df(df, NULL), "`placename` must be provided.")
+})
+
+test_that("output arguments work", {
+  skip_on_cran()
+  skip_if_offline()
+
+  expect_equal(names(oc_forward_df(df, loc, bind_cols = TRUE)),
+               c("id", "loc", "lat", "lng", "formatted"))
+  expect_equal(names(oc_forward_df(df, loc, bind_cols = FALSE)),
+               c("query", "lat", "lng", "formatted"))
+  expect_gt(ncol(oc_forward_df(df, loc, output = "all")), 5)
+  expect_gt(ncol(oc_forward_df(df, loc, bind_cols = FALSE, output = "all")), 5)
+})
+
+test_that("tidyeval works for arguments", {
+  skip_on_cran()
+  skip_if_offline()
+
+  noarg <- oc_forward_df(df2, loc, bind_cols = FALSE)
+
+  ## bounds and countrycode
+  bounds <- oc_forward_df(df2, loc, bounds = bounds, bind_cols = FALSE)
+  cc <- oc_forward_df(df2, loc, countrycode = countrycode, bind_cols = FALSE)
+  expect_false(isTRUE(all.equal(bounds, noarg)))
+  expect_false(isTRUE(all.equal(cc, noarg)))
+  expect_equal(bounds, cc)
+
+  # language
+  lang <- oc_forward_df(df2, loc, language = language, output = "all")
+  expect_equal(lang$country,
+               c("Frankreich", "Allemagne", "Estados Unidos de América"))
+
+  # limit
+  limit <- oc_forward_df(df2, loc, limit = limit)
+  expect_equal(nrow(limit), 6)
+  expect_equal(limit$id, c(1, 2, 2, 3, 3, 3))
+
+  # min_confidence
+  confidence <- oc_forward_df(df2, loc,
+                              min_confidence = confidence,
+                              bind_cols = FALSE)
+  expect_false(isTRUE(all.equal(confidence, noarg)))
+  expect_false(isTRUE(all.equal(confidence[1, ], noarg[1, ])))
+  expect_false(isTRUE(all.equal(confidence[2, ], noarg[2, ])))
+  expect_false(isTRUE(all.equal(confidence[3, ], noarg[3, ])))
+
+  #no_annotations
+  ann <- oc_forward_df(df2, loc, output = "all",
+                       bind_cols = FALSE,
+                       no_annotations = annotation)
+  expect_gt(ncol(ann), 30)
+  expect_equal(ann$currency_name, c("Euro", NA, NA))
+
+  # abbrv
+  abbrv <- oc_forward_df(df2, loc,
+                         abbrv = abbrv,
+                         bind_cols = FALSE)
+  expect_false(isTRUE(all.equal(abbrv, noarg)))
+  expect_true(all.equal(abbrv[1, ], noarg[1, ]))
+  expect_true(all.equal(abbrv[2, ], noarg[2, ]))
+  expect_false(isTRUE(all.equal(abbrv[3, ], noarg[3, ])))
+})

--- a/tests/testthat/test-oc_get.R
+++ b/tests/testthat/test-oc_get.R
@@ -1,8 +1,10 @@
-library("opencage")
-context("oc_get")
+## Test oc_get ##
+
 test_that("oc_get returns a response object", {
   skip_on_cran()
-  expect_is(
+  skip_if_offline()
+
+  expect_s3_class(
     oc_get(
       oc_build_url(
         query_par = list(
@@ -18,7 +20,9 @@ test_that("oc_get returns a response object", {
 
 test_that("oc_get returns a response object for Namibia NA countrycode", {
   skip_on_cran()
-  expect_is(
+  skip_if_offline()
+
+  expect_s3_class(
     oc_get(
       oc_build_url(
         query_par = list(
@@ -35,7 +39,9 @@ test_that("oc_get returns a response object for Namibia NA countrycode", {
 
 test_that("oc_get returns a response object for vector countrycode", {
   skip_on_cran()
-  expect_is(
+  skip_if_offline()
+
+  expect_s3_class(
     oc_get(
       oc_build_url(
         query_par = list(
@@ -52,6 +58,8 @@ test_that("oc_get returns a response object for vector countrycode", {
 
 test_that("oc_get_limited is rate limited", {
   skip_on_cran()
+  skip_if_offline()
+
   tm <- system.time({
     replicate(2, oc_get_limited("https://httpbin.org/get"))
   })
@@ -61,6 +69,8 @@ test_that("oc_get_limited is rate limited", {
 
 test_that("oc_get_memoise memoises", {
   skip_on_cran()
+  skip_if_offline()
+
   oc_get_memoise("https://httpbin.org/get")
   tm <- system.time({
     oc_get_memoise("https://httpbin.org/get")

--- a/tests/testthat/test-oc_process.R
+++ b/tests/testthat/test-oc_process.R
@@ -1,5 +1,4 @@
-library("opencage")
-context("oc_process")
+## Test oc_process ##
 
 test_that("oc_process creates meaningful URLs for single query.", {
   res <-
@@ -8,8 +7,8 @@ test_that("oc_process creates meaningful URLs for single query.", {
       return = "url_only",
       key = NULL
     )
-  expect_is(res, "list")
-  expect_is(unlist(res), "character")
+  expect_type(res, "list")
+  expect_type(unlist(res), "character")
   expect_match(res[[1]], "q=Paris", fixed = TRUE)
 
   res <-
@@ -38,8 +37,8 @@ test_that("oc_process creates meaningful URLs for single query.", {
       return = "url_only",
       key = NULL
     )
-  expect_is(res, "list")
-  expect_is(unlist(res), "character")
+  expect_type(res, "list")
+  expect_type(unlist(res), "character")
   expect_match(res[[1]], "q=41.40139%2C2.1287", fixed = TRUE)
 })
 
@@ -49,8 +48,8 @@ test_that("oc_process creates meaningful URLs for multiple queries.", {
     return = "url_only",
     key = NULL
   )
-  expect_is(res, "list")
-  expect_is(unlist(res), "character")
+  expect_type(res, "list")
+  expect_type(unlist(res), "character")
   expect_match(res[[1]], "q=Paris", fixed = TRUE)
   expect_match(res[[2]], "q=Hamburg", fixed = TRUE)
 
@@ -60,14 +59,16 @@ test_that("oc_process creates meaningful URLs for multiple queries.", {
     return = "url_only",
     key = NULL
   )
-  expect_is(res, "list")
-  expect_is(unlist(res), "character")
+  expect_type(res, "list")
+  expect_type(unlist(res), "character")
   expect_match(res[[1]], "q=48.87378%2C2.295037", fixed = TRUE)
   expect_match(res[[2]], "q=37.83032%2C-122.47975", fixed = TRUE)
 })
 
 test_that("oc_process deals well with res being NULL", {
   skip_on_cran()
+  skip_if_offline()
+
   res <- oc_process(
     placename = "thiswillgetmenoreswhichisgood",
     key = Sys.getenv("OPENCAGE_KEY"),
@@ -111,6 +112,11 @@ test_that("the bounds argument is well taken into account", {
   )
   expect_match(res[[1]], "&bounds=8.1%2C53.39%2C10.32%2C54.02", fixed = TRUE)
   expect_match(res[[2]], "&bounds=-78.86%2C42.7%2C-78.81%2C42.73", fixed = TRUE)
+})
+
+test_that("bounds argument is well taken into account with df_list", {
+  skip_on_cran()
+  skip_if_offline()
 
   res1 <- oc_process(
     placename = "Berlin",

--- a/tests/testthat/test-oc_reverse.R
+++ b/tests/testthat/test-oc_reverse.R
@@ -1,0 +1,127 @@
+## Test oc_forward functions ##
+
+library(tibble)
+lat <- c(47.21864, 53.55034, 34.05369)
+lng <- c(-1.554136, 10.000654, -118.242767)
+df <- tibble(id = 1:3, lat = lat, lng = lng)
+df2 <- add_column(df,
+                  language = c("en", "fr", "es"),
+                  confidence = c(1, 1, 1),
+                  annotation = c(FALSE, TRUE, TRUE),
+                  abbrv = c(FALSE, FALSE, TRUE))
+df3 <- add_row(df2, id = 4, lat = 25, lng = 36, confidence = 5)
+
+
+# oc_reverse --------------------------------------------------------------
+
+test_that("oc_reverse works", {
+  skip_on_cran()
+  skip_if_offline()
+
+  res1 <- oc_reverse(lat, lng)
+  expect_type(res1, "list")
+  expect_equal(length(res1), 3)
+  expect_s3_class(res1[[1]], c("tbl_df", "tbl", "data.frame"))
+})
+
+test_that("oc_reverse returns correct type", {
+  skip_on_cran()
+  skip_if_offline()
+
+  # json_list
+  res2 <- oc_reverse(lat, lng, return = "json_list")
+  expect_type(res2, "list")
+  expect_equal(length(res2), 3)
+  expect_type(res2[[1]], "list")
+
+  # geojson_list
+  res3 <- oc_reverse(lat, lng, return = "geojson_list")
+  expect_type(res3, "list")
+  expect_equal(length(res3), 3)
+  expect_s3_class(res3[[1]], "geo_list")
+})
+
+
+# oc_reverse_df -----------------------------------------------------------
+
+test_that("oc_reverse_df works", {
+  skip_on_cran()
+  skip_if_offline()
+
+  tbl1 <- oc_reverse_df(df, lat, lng)
+  expect_s3_class(tbl1, c("tbl_df", "tbl", "data.frame"))
+  expect_equal(nrow(tbl1), 3)
+
+  tbl2 <- oc_reverse_df(df[1, ], lat, lng)
+  expect_s3_class(tbl2, c("tbl_df", "tbl", "data.frame"))
+  expect_equal(nrow(tbl2), 1)
+})
+
+test_that("output arguments work", {
+  skip_on_cran()
+  skip_if_offline()
+
+  expect_equal(names(oc_reverse_df(df, lat, lng, bind_cols = TRUE)),
+               c("id", "lat", "lng", "formatted"))
+  expect_equal(names(oc_reverse_df(df, lat, lng, bind_cols = FALSE)),
+               c("query", "formatted"))
+  expect_gt(ncol(oc_reverse_df(df, lat, lng, output = "all")), 5)
+  expect_gt(ncol(oc_reverse_df(df, lat, lng, bind_cols = FALSE, output = "all")), 5)
+})
+
+test_that("tidyeval works for arguments", {
+  skip_on_cran()
+  skip_if_offline()
+
+  noarg <- oc_reverse_df(df2, lat, lng)
+
+  # language
+  lang <- oc_reverse_df(df2, lat, lng, language = language, output = "all")
+  expect_equal(lang$country,
+               c("France", "Allemagne", "Estados Unidos de América"))
+
+  # min_confidence
+  confidence <- oc_reverse_df(df3, lat, lng, min_confidence = confidence)
+  no_con <- oc_reverse_df(df3, lat, lng)
+
+  expect_false(isTRUE(all.equal(confidence, no_con)))
+  expect_true(isTRUE(all.equal(confidence[1, ], no_con[1, ])))
+  expect_true(isTRUE(all.equal(confidence[2, ], no_con[2, ])))
+  expect_true(isTRUE(all.equal(confidence[3, ], no_con[3, ])))
+  expect_false(isTRUE(all.equal(confidence[4, ], no_con[4, ])))
+
+  #no_annotations
+  ann <- oc_reverse_df(df2, lat, lng, output = "all",
+                       bind_cols = FALSE,
+                       no_annotations = annotation)
+  expect_gt(ncol(ann), 40)
+  expect_equal(ann$currency_name, c("Euro", NA, NA))
+
+  # abbrv
+  abbrv <- oc_reverse_df(df2, lat, lng,
+                         abbrv = abbrv)
+  expect_false(isTRUE(all.equal(abbrv, noarg)))
+  expect_true(all.equal(abbrv[1, ], noarg[1, ]))
+  expect_true(all.equal(abbrv[2, ], noarg[2, ]))
+  expect_false(isTRUE(all.equal(abbrv[3, ], noarg[3, ])))
+})
+
+# Checks ------------------------------------------------------------------
+
+test_that("Checks work", {
+  # oc_reverse
+  expect_error(oc_reverse(latitude = lat),
+               "`latitude` and `longitude` must be provided.")
+  expect_error(oc_reverse(longitude = lng),
+               "`latitude` and `longitude` must be provided.")
+  expect_error(oc_reverse(latitude = NULL, longitude = lng),
+               "`latitude` and `longitude` must be provided.")
+  expect_error(oc_reverse(latitude = lat, longitude = NULL),
+               "`latitude` and `longitude` must be provided.")
+
+  # oc_reverse_df
+  expect_error(oc_reverse_df(df, latitude = lat),
+               "`latitude` and `longitude` must be provided.")
+  expect_error(oc_reverse_df(df, longitude = lng),
+               "`latitude` and `longitude` must be provided.")
+})

--- a/tests/testthat/test-opencage_forward.R
+++ b/tests/testthat/test-opencage_forward.R
@@ -1,8 +1,9 @@
-library("opencage")
-context("opencage_forward")
+## Test deprecated opencage_forward ##
 
 test_that("opencage_forward/opencage_reverse return what they should.", {
   skip_on_cran()
+  skip_if_offline()
+
   results <- opencage_forward(placename = "Sarzeau")
   expect_is(results, "list")
   expect_is(results[["results"]], "tbl_df")
@@ -40,6 +41,7 @@ test_that("opencage_forward/opencage_reverse return what they should.", {
 test_that("opencage_forward/opencage_reverse return what they should
           with several parameters.", {
   skip_on_cran()
+  skip_if_offline()
 
   results <- opencage_forward(
     placename = "Paris",
@@ -82,6 +84,9 @@ test_that("opencage_forward/opencage_reverse return what they should
 })
 
 test_that("opencage_forward deals well with results being NULL", {
+  skip_on_cran()
+  skip_if_offline()
+
   results <- opencage_forward(
     placename = "thiswillgetmenoresultswichisgood",
     key = Sys.getenv("OPENCAGE_KEY"),
@@ -98,6 +103,9 @@ test_that("opencage_forward deals well with results being NULL", {
 
 
 test_that("the bounds argument is well taken into account", {
+  skip_on_cran()
+  skip_if_offline()
+
   results1 <- opencage_forward(
     placename = "Berlin",
     key = Sys.getenv("OPENCAGE_KEY")


### PR DESCRIPTION
* Remove context from test files in accordance with testthat 2.1.
* Use skip_on_cran() and skip_if_offline() for tests that need internet connection.
* Add tests for oc_forward(), oc_forward_df(), oc_reverse(), and oc_reverse_df()
* Remove sf::st_bbox() from oc_bbox test, which gets rid of warning in devtools::check().