### PR TITLE
Improve coverage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,8 +29,9 @@ Imports:
 Suggests: 
     knitr (>= 1.19),
     rmarkdown (>= 1.8),
+    sf (>= 0.7),
     testthat (>= 2.1.0),
-    sf
+    withr (>= 2.0.0)
 VignetteBuilder: knitr
 Encoding: UTF-8
 Language: en-GB

--- a/R/oc_process.R
+++ b/R/oc_process.R
@@ -136,7 +136,7 @@ oc_process <-
       } else {
         stop(
           call. = FALSE,
-          "'url_only' reveals your opencage key.
+          "'url_only' reveals your OpenCage key.
           It is therefore only available in interactive mode."
         )
       }

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,10 +14,7 @@ oc_check_status <- function(res_env, res_text) {
 oc_parse_text <- function(res) {
   text <- res$parse(encoding = "UTF-8")
   if (identical(text, "")) {
-    stop(
-      "OpenCage returned an empty response.",
-      call. = FALSE
-    )
+    stop("OpenCage returned an empty response.", call. = FALSE)
   }
   text
 }

--- a/tests/testthat/test-oc_bbox.R
+++ b/tests/testthat/test-oc_bbox.R
@@ -23,6 +23,10 @@ test_that("oc_bbox works with numeric", {
       ymax = 51.6
     )
   )
+  expect_output(
+    object = print(bbox1),
+    regexp = "xmin ymin xmax ymax \\n-5.6 51.2  0.2 51.6"
+  )
 })
 
 test_that("oc_bbox works with data.frame", {
@@ -76,6 +80,7 @@ test_that("oc_bbox works with data.frame", {
 
 test_that("oc_bbox works with simple features bbox", {
   skip_if_not_installed("sf")
+
   sfbbox <-
     sf::st_bbox(c(
       xmin = 16.1,
@@ -107,5 +112,19 @@ test_that("oc_bbox works with simple features bbox", {
       xmax = 16.6,
       ymax = 48.6
     )
+  )
+
+  sfbbox_3857 <-
+    sf::st_bbox(c(
+      xmin = 1792244,
+      ymin = 6090234,
+      xmax = 1847904,
+      ymax = 6207260
+    ),
+    crs = 3857
+    )
+  expect_error(
+    object = oc_bbox(sfbbox_3857),
+    regexp = "The coordinate reference system of `bbox` must be EPSG 4326."
   )
 })

--- a/tests/testthat/test-oc_check_query.R
+++ b/tests/testthat/test-oc_check_query.R
@@ -59,6 +59,17 @@ test_that("oc_check_query checks key", {
   )
 })
 
+test_that("oc_check_query checks bounds", {
+  expect_error(
+    oc_check_query(
+      placename = "Sarzeau",
+      key = "32randomlettersanddigits12345678",
+      bounds = list(c(-5, 51, 0))
+    ),
+    "Every `bbox` must be a numeric vector of length 4."
+  )
+})
+
 test_that("oc_check_query checks countrycode", {
   expect_error(
     oc_check_query(

--- a/tests/testthat/test-oc_forward.R
+++ b/tests/testthat/test-oc_forward.R
@@ -59,10 +59,6 @@ test_that("oc_forward_df works", {
   tbl2 <- oc_forward_df(tibble(loc = "Nantes"), loc)
   expect_s3_class(tbl2, c("tbl_df", "tbl", "data.frame"))
   expect_equal(nrow(tbl2), 1)
-
-  # Error with no placename
-  expect_error(oc_forward_df(df), "`placename` must be provided.")
-  expect_error(oc_forward_df(df, NULL), "`placename` must be provided.")
 })
 
 test_that("output arguments work", {
@@ -124,4 +120,16 @@ test_that("tidyeval works for arguments", {
   expect_true(all.equal(abbrv[1, ], noarg[1, ]))
   expect_true(all.equal(abbrv[2, ], noarg[2, ]))
   expect_false(isTRUE(all.equal(abbrv[3, ], noarg[3, ])))
+})
+
+# Checks ------------------------------------------------------------------
+
+test_that("Check that placename is present work", {
+  # oc_forward
+  expect_error(oc_forward(), "`placename` must be provided.")
+  expect_error(oc_forward(placename = NULL), "`placename` must be provided.")
+
+  # oc_forward_df
+  expect_error(oc_forward_df(df), "`placename` must be provided.")
+  expect_error(oc_forward_df(df, NULL), "`placename` must be provided.")
 })

--- a/tests/testthat/test-oc_key.R
+++ b/tests/testthat/test-oc_key.R
@@ -1,0 +1,13 @@
+## Test oc_key ##
+test_that("`oc_key()` returns NULL if the OPENCAGE_KEY envvar is not found", {
+  withr::local_envvar(c("OPENCAGE_KEY" = ""))
+  expect_null(oc_key())
+})
+
+test_that("`oc_key(quiet = FALSE)` messages", {
+  withr::local_envvar(c("OPENCAGE_KEY" = "fakekey"))
+  expect_message(
+    object = oc_key(quiet = FALSE),
+    regexp = "Using Opencage API Key from envvar OPENCAGE_KEY"
+  )
+})

--- a/tests/testthat/test-oc_process.R
+++ b/tests/testthat/test-oc_process.R
@@ -1,5 +1,18 @@
 ## Test oc_process ##
 
+test_that("oc_process does not reveal key with non-interactive `url_only`.", {
+  # This test (intentionally) fails in interactive mode.
+  expect_error(
+    object =
+      oc_process(
+        placename = "Paris",
+        return = "url_only",
+        key = "fakekey"
+      ),
+    regexp = "'url_only' reveals your OpenCage key"
+  )
+})
+
 test_that("oc_process creates meaningful URLs for single query.", {
   res <-
     oc_process(
@@ -25,7 +38,8 @@ test_that("oc_process creates meaningful URLs for single query.", {
       return = "url_only",
       key = NULL
     )
-  expect_match(res[[1]],
+  expect_match(
+    res[[1]],
     "q=Triererstr%2015%2C%2099423%20Weimar%2C%20Deutschland",
     fixed = TRUE
   )

--- a/tests/testthat/test-oc_reverse.R
+++ b/tests/testthat/test-oc_reverse.R
@@ -66,7 +66,10 @@ test_that("output arguments work", {
   expect_equal(names(oc_reverse_df(df, lat, lng, bind_cols = FALSE)),
                c("query", "formatted"))
   expect_gt(ncol(oc_reverse_df(df, lat, lng, output = "all")), 5)
-  expect_gt(ncol(oc_reverse_df(df, lat, lng, bind_cols = FALSE, output = "all")), 5)
+  expect_gt(
+    ncol(oc_reverse_df(df, lat, lng, bind_cols = FALSE, output = "all")),
+    5
+  )
 })
 
 test_that("tidyeval works for arguments", {

--- a/tests/testthat/test-oc_reverse.R
+++ b/tests/testthat/test-oc_reverse.R
@@ -1,4 +1,4 @@
-## Test oc_forward functions ##
+## Test oc_reverse functions ##
 
 library(tibble)
 lat <- c(47.21864, 53.55034, 34.05369)

--- a/tests/testthat/test-opencage_forward.R
+++ b/tests/testthat/test-opencage_forward.R
@@ -120,3 +120,14 @@ test_that("the bounds argument is well taken into account", {
   expect_true(!("Germany" %in% results2$results$components.country))
   expect_true("Germany" %in% results1$results$components.country)
 })
+
+test_that("opencage_forward & opencage_reverse are not vectorised.", {
+  expect_error(
+    object = opencage_forward(c("Trier", "Ulm")),
+    regexp = "`opencage_forward` is not vectorised"
+  )
+  expect_error(
+    opencage_reverse(latitude = c(47,53), longitude = c(-1.5, 10)),
+    regexp = "`opencage_reverse` is not vectorised"
+  )
+})

--- a/tests/testthat/test-opencage_forward.R
+++ b/tests/testthat/test-opencage_forward.R
@@ -127,7 +127,7 @@ test_that("opencage_forward & opencage_reverse are not vectorised.", {
     regexp = "`opencage_forward` is not vectorised"
   )
   expect_error(
-    opencage_reverse(latitude = c(47,53), longitude = c(-1.5, 10)),
+    opencage_reverse(latitude = c(47, 53), longitude = c(-1.5, 10)),
     regexp = "`opencage_reverse` is not vectorised"
   )
 })


### PR DESCRIPTION
I added a few tests to improve test coverage. 
The `oc_key()` introduces a Suggests dependency on {withr}, in order to temporarily set  a different key/env var. But that should be fine, since {withr} is a direct dependency of {testthat}.