### PR TITLE
oc_check_query for NAs in placename or latitude/longitude

### DIFF
--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -63,7 +63,7 @@ opencage_forward <-
     lst <- oc_forward(
       placename = placename,
       key = key,
-      return = c("json_list"),
+      return = "json_list",
       bounds = list(bounds),
       countrycode = countrycode,
       language = language,
@@ -128,7 +128,7 @@ opencage_reverse <-
       latitude = latitude,
       longitude = longitude,
       key = key,
-      return = c("json_list"),
+      return = "json_list",
       language = language,
       limit = limit,
       min_confidence = min_confidence,

--- a/R/oc_check_query.R
+++ b/R/oc_check_query.R
@@ -84,7 +84,9 @@ oc_check_query <-
     # check placename
     if (!is.null(placename)) {
       if (!is.character(placename)) {
-        stop(call. = FALSE, "`placename` must be a character vector.")
+        stop("`placename` must be a character vector.", call. = FALSE)
+      } else if (is.na(placename) || placename == "") {
+        stop("`placename` must not be NA or an empty string.", call. = FALSE)
       }
     }
 
@@ -92,10 +94,10 @@ oc_check_query <-
     if (!is.null(latitude)) {
       if (!is.numeric(latitude)) {
         stop("Every `latitude` must be numeric.", call. = FALSE)
-      } else if (!is.na(latitude)) {
-        if (!dplyr::between(latitude, -90, 90)) {
-          stop("Every `latitude` must be between -90 and 90.", call. = FALSE)
-        }
+      } else if (is.na(latitude)) {
+        stop("`latitude` must not be NA.", call. = FALSE)
+      } else if (!dplyr::between(latitude, -90, 90)) {
+        stop("Every `latitude` must be between -90 and 90.", call. = FALSE)
       }
     }
 
@@ -103,10 +105,10 @@ oc_check_query <-
     if (!is.null(longitude)) {
       if (!is.numeric(longitude)) {
         stop("Every `longitude` must be numeric.", call. = FALSE)
-      } else if (!is.na(longitude)) {
-        if (!dplyr::between(longitude, -180, 180)) {
-          stop("Every `longitude` must be between -180 and 180.", call. = FALSE)
-        }
+      } else if (is.na(longitude)) {
+        stop("`longitude` must not be NA.", call. = FALSE)
+      } else if (!dplyr::between(longitude, -180, 180)) {
+        stop("Every `longitude` must be between -180 and 180.", call. = FALSE)
       }
     }
 

--- a/tests/testthat/test-oc_check_query.R
+++ b/tests/testthat/test-oc_check_query.R
@@ -8,6 +8,20 @@ test_that("oc_check_query checks placename", {
     ),
     "`placename` must be a character vector."
   )
+  expect_error(
+    oc_check_query(
+      placename = NA_character_,
+      key = "32randomlettersanddigits12345678"
+    ),
+    "`placename` must not be NA or an empty string."
+  )
+  expect_error(
+    oc_check_query(
+      placename = "",
+      key = "32randomlettersanddigits12345678"
+    ),
+    "`placename` must not be NA or an empty string."
+  )
 })
 
 test_that("oc_check_query checks latitude", {
@@ -27,12 +41,13 @@ test_that("oc_check_query checks latitude", {
     ),
     "Every `latitude` must be between -90 and 90."
   )
-  expect_silent(
+  expect_error(
     oc_check_query(
       latitude = NA_real_,
       longitude = 51.11892,
       key = "32randomlettersanddigits12345678"
-    )
+    ),
+    "`latitude` must not be NA."
   )
 })
 
@@ -53,12 +68,13 @@ test_that("oc_check_query checks longitude", {
     ),
     "Every `longitude` must be between -180 and 180."
   )
-  expect_silent(
+  expect_error(
     oc_check_query(
       latitude = 43,
       longitude = NA_real_,
       key = "32randomlettersanddigits12345678"
-    )
+    ),
+    "`longitude` must not be NA."
   )
 })
 

--- a/tests/testthat/test-oc_check_status.R
+++ b/tests/testthat/test-oc_check_status.R
@@ -4,16 +4,39 @@
 # https://github.com/OpenCageData/opencagedata-misc-docs/blob/master/library-guidelines.md # nolint
 key_402 <- "4372eff77b8343cebfc843eb4da4ddc4" # always returns a 402 responce
 key_403 <- "2e10e5e828262eb243ec0b54681d699a" # always returns a 403 responce
+key_429 <- "d6d0f0065f4348a4bdfe4587ba02714b" # always returns a 429 responce
+
+test_that("oc_check_status returns 400 error if request is invalid", {
+  skip_on_cran()
+  skip_if_offline()
+
+  # Both shouldn't happen since we oc_check_query
+  expect_error(
+    oc_process(latitude = 280, longitude = 0, return = "json_list"),
+    "HTTP failure: 400"
+  )
+  expect_error(
+    oc_process(placename = "", return = "json_list"),
+    "HTTP failure: 400"
+  )
+})
+
+test_that("oc_check_status returns 401 error if key is invalid", {
+  skip_on_cran()
+  skip_if_offline()
+
+  expect_error(
+    oc_reverse(latitude = 0, longitude = 0, key = "thisisaninvalidkey"),
+    "HTTP failure: 401"
+  )
+})
 
 test_that("oc_check_status returns 402 error if quota exceeded", {
   skip_on_cran()
   skip_if_offline()
 
   expect_error(
-    oc_reverse(
-      latitude = 0, longitude = 0,
-      key = key_402
-    ),
+    oc_reverse(latitude = 0, longitude = 0, key = key_402),
     "HTTP failure: 402"
   )
 })
@@ -23,34 +46,17 @@ test_that("oc_check_status returns 403 error if key is blocked", {
   skip_if_offline()
 
   expect_error(
-    oc_reverse(
-      latitude = 0, longitude = 0,
-      key = key_403
-    ),
+    oc_reverse(latitude = 0, longitude = 0, key = key_403),
     "HTTP failure: 403"
   )
 })
 
-test_that("oc_check_status returns 401 error if key is invalid", {
+test_that("oc_check_status returns 429 error if rate limit is exceeded", {
   skip_on_cran()
   skip_if_offline()
 
   expect_error(
-    oc_reverse(
-      latitude = 0, longitude = 0,
-      key = "thisisaninvalidkey"
-    ),
-    "HTTP failure: 401"
-  )
-})
-
-# Shouldn't happen since we oc_check coordinates
-test_that("oc_check_status returns 400 error if coordinates are invalid", {
-  skip_on_cran()
-  skip_if_offline()
-
-  expect_error(
-    oc_process(latitude = 280, longitude = 0, return = "json_list"),
-    "HTTP failure: 400"
+    oc_reverse(latitude = 0, longitude = 0, key = key_429),
+    "HTTP failure: 429"
   )
 })

--- a/tests/testthat/test-oc_forward.R
+++ b/tests/testthat/test-oc_forward.R
@@ -52,24 +52,6 @@ test_that("oc_forward returns correct type", {
   expect_s3_class(res3[[1]], "geo_list")
 })
 
-test_that("oc_forward can handle NAs", {
-  skip_on_cran()
-  skip_if_offline()
-
-  res <- oc_forward(NA_character_, return = "df_list")
-  expect_s3_class(res[[1]], "data.frame")
-  expect_equal(res[[1]][["oc_formatted"]], NA_character_)
-
-  res <- oc_forward(NA_character_, return = "json_list")
-  expect_equal(res[[1]][["total_results"]], 0)
-  expect_equal(res[[1]][["results"]], list())
-
-  res <- oc_forward(NA_character_, return = "geojson_list")
-  expect_s3_class(res[[1]], "geo_list")
-  expect_equal(res[[1]][["total_results"]], 0)
-  expect_equal(res[[1]][["features"]], list())
-})
-
 # oc_forward_df -----------------------------------------------------------
 
 test_that("oc_forward_df works", {

--- a/tests/testthat/test-oc_reverse.R
+++ b/tests/testthat/test-oc_reverse.R
@@ -41,36 +41,6 @@ test_that("oc_reverse returns correct type", {
   expect_s3_class(res3[[1]], "geo_list")
 })
 
-test_that("oc_reverse can handle NAs", {
-  skip_on_cran()
-  skip_if_offline()
-
-  res1 <- oc_reverse(0, NA_real_, return = "df_list")
-  res2 <- oc_reverse(NA_real_, 0, return = "df_list")
-  res3 <- oc_reverse(NA_real_, NA_real_, return = "df_list")
-  expect_equal(res1, res2)
-  expect_equal(res1, res3)
-  expect_s3_class(res1[[1]], "data.frame")
-  expect_equal(res1[[1]][["oc_formatted"]], NA_character_)
-
-  res1 <- oc_reverse(0, NA_real_, return = "json_list")
-  res2 <- oc_reverse(NA_real_, 0, return = "json_list")
-  res3 <- oc_reverse(NA_real_, NA_real_, return = "json_list")
-  expect_equal(res1, res2) # fails if results are not memoised
-  expect_equal(res1, res3) # fails if results are not memoised
-  expect_equal(res1[[1]][["total_results"]], 0)
-  expect_equal(res1[[1]][["results"]], list())
-
-  res1 <- oc_reverse(0, NA_real_, return = "geojson_list")
-  res2 <- oc_reverse(NA_real_, 0, return = "geojson_list")
-  res3 <- oc_reverse(NA_real_, NA_real_, return = "geojson_list")
-  expect_equal(res1, res2) # fails if results are not memoised
-  expect_equal(res1, res3) # fails if results are not memoised
-  expect_s3_class(res1[[1]], "geo_list")
-  expect_equal(res1[[1]][["total_results"]], 0)
-  expect_equal(res1[[1]][["features"]], list())
-})
-
 # oc_reverse_df -----------------------------------------------------------
 
 test_that("oc_reverse_df works", {


### PR DESCRIPTION
As of recently, OpenCage throws a HTTP 400 ‘bad query’ error when the query is empty, so we cannot be as sneaky as in \#89 anymore.
I.e. now we need to make sure that we do not send empty queries (empty placename
or latitude/longitude) to the API, but alert the user beforehand. This is what happens with this PR.

An empty request throws an HTTP 400 error (shown with `oc_process()` here, but the same happens with `oc_forward()` and `oc_reverse()` without this fix):

``` r
library(opencage)
opencage:::oc_process("", return = "df_list")
#> Error: HTTP failure: 401
#> missing API key
```

Instead, `oc_check_query()` now throws an error before moving to `oc_process()`/calling the API:

``` r
oc_forward("")
#> Error: `placename` must not be NA or an empty string.
oc_reverse(NA_real_, NA_real_)
#> Error: `latitude` must not be NA.
```

I was a bit reluctant to let the whole call error out ‘just’ because a user provides an empty/NA placename/coordinates, but this is a) what the API effectively demands now and b) essentially the same as providing incorrect coordinates, e.g. outside the (-)90/(-)180 bounds:

``` r
oc_reverse(100, 200)
#> Error: Every `latitude` must be between -90 and 90.
```
