### PR TITLE
Fix ambiguous tests

### DIFF
--- a/tests/testthat/test-oc_forward.R
+++ b/tests/testthat/test-oc_forward.R
@@ -1,19 +1,19 @@
 ## Test oc_forward functions ##
 
 library(tibble)
-locations <- c("Nantes", "Hamburg", "Los Angeles")
+locations <- c("Nantes", "Flensburg", "Los Angeles")
 df <- tibble(id = 1:3, loc = locations)
 df2 <- add_column(df,
-                  bounds = oc_bbox(xmin = c(-72, -80, -76),
-                                   ymin = c(45, 42, 8),
-                                   xmax = c(-70, -78, -74),
-                                   ymax = c(46, 43, 10)),
-                  proximity = oc_points(latitude = c(45.5, 42.5, 9),
-                                        longitude = c(-71, -79, -75)),
+                  bounds = oc_bbox(xmin = c(-72, -98, -76),
+                                   ymin = c(45, 43, 8),
+                                   xmax = c(-70, -90, -74),
+                                   ymax = c(46, 49, 10)),
+                  proximity = oc_points(latitude = c(45.5, 46, 9),
+                                        longitude = c(-71, -95, -75)),
                   countrycode = c("ca", "us", "co"),
                   language = c("de", "fr", "ja"),
                   limit = 1:3,
-                  confidence = c(7, 5, 3),
+                  confidence = c(7, 9, 3),
                   annotation = c(FALSE, TRUE, TRUE),
                   abbrv = c(FALSE, FALSE, TRUE))
 

--- a/tests/testthat/test-oc_forward.R
+++ b/tests/testthat/test-oc_forward.R
@@ -70,6 +70,13 @@ test_that("oc_forward can handle NAs", {
   expect_equal(res[[1]][["features"]], list())
 })
 
+test_that("oc_forward adds request with add_request", {
+  skip_on_cran()
+  skip_if_offline()
+  res <- oc_forward("Hmbg", add_request = TRUE)
+  expect_equal(res[[1]][["oc_query"]], "Hmbg")
+})
+
 # oc_forward_df -----------------------------------------------------------
 
 test_that("oc_forward_df works", {

--- a/tests/testthat/test-oc_forward.R
+++ b/tests/testthat/test-oc_forward.R
@@ -11,7 +11,7 @@ df2 <- add_column(df,
                   proximity = oc_points(latitude = c(45.5, 42.5, 9),
                                         longitude = c(-71, -79, -75)),
                   countrycode = c("ca", "us", "co"),
-                  language = c("de", "fr", "es"),
+                  language = c("de", "fr", "ja"),
                   limit = 1:3,
                   confidence = c(7, 5, 3),
                   annotation = c(FALSE, TRUE, TRUE),
@@ -126,7 +126,7 @@ test_that("tidyeval works for arguments", {
 
   # language
   lang <- oc_forward_df(df2, loc, language = language, output = "all")
-  expect_equal(lang$oc_country, c("Frankreich", "Allemagne", "EE.UU."))
+  expect_equal(lang$oc_country, c("Frankreich", "Allemagne", "アメリカ合衆国"))
 
   # limit
   limit <- oc_forward_df(df2, loc, limit = limit)

--- a/tests/testthat/test-oc_reverse.R
+++ b/tests/testthat/test-oc_reverse.R
@@ -5,7 +5,7 @@ lat <- c(47.21864, 53.55034, 34.05369)
 lng <- c(-1.554136, 10.000654, -118.242767)
 df <- tibble(id = 1:3, lat = lat, lng = lng)
 df2 <- add_column(df,
-                  language = c("en", "fr", "es"),
+                  language = c("en", "fr", "ja"),
                   confidence = c(1, 1, 1),
                   annotation = c(FALSE, TRUE, TRUE),
                   roadinfo = c(FALSE, TRUE, TRUE),
@@ -120,7 +120,7 @@ test_that("tidyeval works for arguments", {
 
   # language
   lang <- oc_reverse_df(df2, lat, lng, language = language, output = "all")
-  expect_equal(lang$oc_country, c("France", "Allemagne", "EE.UU."))
+  expect_equal(lang$oc_country, c("France", "Allemagne", "アメリカ合衆国"))
 
   # min_confidence
   confidence <- oc_reverse_df(df3, lat, lng, min_confidence = confidence)


### PR DESCRIPTION
I had a few tests fail sporadically and changed them to queries with less ambiguous results.

E.g. for `oc_forward("Los Angeles", language = "es")` I sometimes get "Estados Unidos" and sometimes "EE.UU." in the `country` field. For `oc_forward("Hamburg", countrycode = "us")` I usually get Hamburg, New York, but not always and since it is compared to the results with `bounds` roughly set to New York State in tests, this is problematic.

I also added a test for `oc_forward(add_request = TRUE)` with an empty response, because coverage.