### PR TITLE
oc_config(no_record)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: opencage
 Title: Geocode with the OpenCage API
-Version: 0.1.4.9004
+Version: 0.1.4.9005
 Authors@R: c(
     person("Maëlle", "Salmon", email = "maelle.salmon@yahoo.se", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2815-0399")), 
     person("Daniel", "Possenriede", role = "aut", comment = c(ORCID = "0000-0002-6738-9845")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,25 +1,25 @@
-# opencage 0.1.4.9002
+# opencage 0.1.4.9005
 
-This is a major rewrite of the {opencage} package. `opencage_forward()` and `opencage_reverse()` have been deprecated and are superseded by `oc_forward()` and `oc_reverse()`, respectively. In addition there are two new functions `oc_forward_df()` and `oc_reverse_df()`, which (reverse) geocode a `placename` column (or `latitude`/`longitude` columns) in a data frame. 
+This is a major rewrite of the {opencage} package. `opencage_forward()` and `opencage_reverse()` have been deprecated and are superseded by `oc_forward()` and `oc_reverse()`, respectively. In addition there are two new functions `oc_forward_df()` and `oc_reverse_df()`, which (reverse) geocode a `placename` column (or `latitude`/`longitude` columns) and return a data frame. 
 
 The new features include:
 
-* `oc_forward()` and `oc_reverse()` return either lists of data frames, JSON strings, GeoJSON strings, or URLs to be sent to the API (for debugging purposes).
-* `oc_forward_df()` and `oc_reverse_df()` take a data frame as input and return a data frame with the geocoding results, optionally with the source data frame bound to the results data frame. 
-* Almost all arguments of the geocoding functions are vectorised (the exceptions being `output`, `key` and `no_record`), so it is possible to serially (reverse) geocode lists of placenames or coordinates. The geocoding functions show a progress indicator when more than one `placename` or `latitude`/`longitude` pair is provided.
+* `oc_forward()` and `oc_reverse()` return either lists of data frames, JSON strings, GeoJSON strings, or URLs to be sent to the API (the latter for debugging purposes).
+* `oc_forward_df()` and `oc_reverse_df()` take a data frame or vectors as input and return a data frame with the geocoding results, optionally with the source data frame bound to the results data frame. 
+* Almost all arguments of the geocoding functions are vectorised (the exceptions being `output`), so it is possible to serially (reverse) geocode lists of placenames or coordinates. The geocoding functions show a progress indicator when more than one `placename` or `latitude`/`longitude` pair is provided.
 * The forward geocoding functions now support multiple `countrycode`s in accordance with the OpenCage API (#44). The `countrycode`s can now be provided in upper or lower case (#47).
 * A helper function `oc_bbox()` now makes it easier to create a list of bounding boxes from numeric vectors, bbox objects or data frames. 
 * `oc_forward` and `oc_forward_df` now support [OpenCage's `proximity` parameter](https://blog.opencagedata.com/post/new-optional-parameter-proximity). The results of the geocoding request will be biased towards that location (#60).
 * A helper function `oc_points()` now makes it easier to create a list of point coordinates from numeric vectors or data frames to pass to the `proximity` argument for example. 
 * All geocoding functions now support [OpenCage's `roadinfo` parameter](https://blog.opencagedata.com/post/new-optional-parameter-roadinfo) (#65). If set to `TRUE`, OpenCage attempts to match the nearest road (rather than an address) and provides additional road and driving information.
-* Language tags passed to the `language` argument are not validated anymore, since the language tags used by OpenStreetMap and hence OpenCage do not always conform with the IETF BCP 47 standard (#90). The `languagecodes`, which were stored in opencage as external data, have therefore been omitted from the package. In addition, it is now possible to specify `language = "native"`, so OpenCage will attempt to return the [results in the "official" language](https://blog.opencagedata.com/post/support-for-local-language) of the country. 
+* Language tags passed to the `language` argument are not validated anymore, since the language tags used by OpenStreetMap and hence OpenCage do not always conform with the IETF BCP 47 standard (#90). The `languagecodes`, which were stored in {opencage} as external data, have therefore been omitted from the package. In addition, it is now possible to specify `language = "native"`, so OpenCage will attempt to return the [results in the "official" language](https://blog.opencagedata.com/post/support-for-local-language) of the country. 
 * http requests are now handled by {[crul](https://docs.ropensci.org/crul/)}, not {[httr](http://httr.r-lib.org/)} (#37).
 * API calls are now rate limited (#32). The default limit is set to 1 call per second as per the API limit of the [Free Trial plan](https://opencagedata.com/pricing).
-* You can configure your {opencage} settings like your OpenCage API key or the API rate limit with `oc_config()`.
+* {opencage} settings like the OpenCage API key or the API rate limit can be configured with `oc_config()`. If you want OpenCage to have no record of the contents of your queries, you can also set the `no_record` parameter for the active R session with `oc_config()` (as opposed to providing the parameter with each function call). All `oc_config()` settings can be set more permanently via `options()` or environment variables, see `help(oc_config)`.
 
 ## Breaking changes
 
-* `opencage_forward()`, `opencage_reverse()`, and `opencage_key()` are (soft) deprecated. `opencage_key()` has just been renamed to `oc_key()` for consistency.
+* `opencage_forward()`, `opencage_reverse()`, and `opencage_key()` are (soft) deprecated. 
 * `opencage_forward()` and `opencage_reverse()` will always output strings as characters, i.e. they won't coerce to factor depending on the `stringsAsFactor` option.
 
 ## Minor changes

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -19,6 +19,9 @@ NULL
 #' @param key Your OpenCage API key as a character vector of length one. By
 #'   default, \code{\link{opencage_key}} will attempt to retrieve the key from
 #'   the environment variable \code{OPENCAGE_KEY}.
+#' @param no_record Logical vector of length one (default \code{FALSE}), when
+#'   \code{TRUE} no log entry of the query is created, and the geocoding
+#'   request is not cached by OpenCage.
 #' @inheritParams oc_forward
 #'
 #' @return A list with
@@ -63,7 +66,7 @@ opencage_forward <-
 
     .Deprecated("oc_forward")
 
-    oc_config(key = key)
+    oc_config(key = key, no_record = no_record)
 
     lst <- oc_forward(
       placename = placename,
@@ -75,7 +78,6 @@ opencage_forward <-
       min_confidence = min_confidence,
       no_annotations = no_annotations,
       no_dedupe = no_dedupe,
-      no_record = no_record,
       abbrv = abbrv,
       add_request = add_request
     )
@@ -89,14 +91,12 @@ opencage_forward <-
 #' Deprecated: use \code{oc_reverse} or \code{oc_reverse_df} for reverse
 #' geocoding.
 #'
-#' @param key Your OpenCage API key as a character vector of length one. By
-#'   default, \code{\link{opencage_key}} will attempt to retrieve the key from
-#'   the environment variable \code{OPENCAGE_KEY}.
 #' @param bounds Bounding box, ignored for reverse geocoding.
 #' @param countrycode Country code, ignored for reverse geocoding.
 #' @param limit How many results should be returned (1-100), ignored for reverse
 #'   geocoding.
 #' @inheritParams oc_reverse
+#' @inheritParams opencage_forward
 #' @inherit opencage_forward return
 #'
 #' @export
@@ -131,7 +131,7 @@ opencage_reverse <-
 
     .Deprecated("oc_reverse")
 
-    oc_config(key = key)
+    oc_config(key = key, no_record = no_record)
 
     lst <- oc_reverse(
       latitude = latitude,
@@ -142,7 +142,6 @@ opencage_reverse <-
       min_confidence = min_confidence,
       no_annotations = no_annotations,
       no_dedupe = no_dedupe,
-      no_record = no_record,
       abbrv = abbrv,
       add_request = add_request
     )

--- a/R/oc_check_query.R
+++ b/R/oc_check_query.R
@@ -1,3 +1,21 @@
+oc_check_logical <- function(variable, check_length_one = FALSE) {
+  if (!is.null(variable)) {
+    if (!is.logical(variable)) {
+      var_name <- deparse(substitute(variable)) # deparse only if check fails
+      stop(
+        paste0("`", var_name, "` must be a logical vector."),
+        call. = FALSE
+      )
+    } else if (check_length_one && !identical(length(variable), 1L)) {
+      var_name <- deparse(substitute(variable)) # deparse only if check fails
+      stop(
+        paste0("`", var_name, "` must be a vector of length one."),
+        call. = FALSE
+      )
+    }
+  }
+}
+
 #' Check OpenCage query arguments
 #'
 #' Function that checks the query arguments passed to OpenCage
@@ -22,7 +40,6 @@ oc_check_query <-
     no_annotations = NULL,
     roadinfo = NULL,
     no_dedupe = NULL,
-    no_record = NULL,
     abbrv = NULL,
     add_request = NULL
   ) {
@@ -55,8 +72,7 @@ oc_check_query <-
 
     purrr::pwalk(
       .l = arglist,
-      .f = .oc_check_query,
-      no_record = no_record
+      .f = .oc_check_query
     )
   }
 
@@ -74,7 +90,6 @@ oc_check_query <-
     no_annotations = NULL,
     roadinfo = NULL,
     no_dedupe = NULL,
-    no_record = NULL,
     abbrv = NULL,
     add_request = NULL
   ) {
@@ -181,47 +196,14 @@ oc_check_query <-
       }
     }
 
-    # check no_annotations
-    if (!is.null(no_annotations)) {
-      if (!is.logical(no_annotations)) {
-        stop(call. = FALSE, "`no_annotations` must be a logical vector.")
-      }
-    }
+    oc_check_logical(no_annotations)
 
-    # check no_annotations
-    if (!is.null(roadinfo)) {
-      if (!is.logical(roadinfo)) {
-        stop(call. = FALSE, "`roadinfo` must be a logical vector.")
-      }
-    }
+    oc_check_logical(roadinfo)
 
-    # check no_dedupe
-    if (!is.null(no_dedupe)) {
-      if (!is.logical(no_dedupe)) {
-        stop(call. = FALSE, "`no_dedupe` must be a logical vector.")
-      }
-    }
+    oc_check_logical(no_dedupe)
 
-    # check no_record
-    if (!is.null(no_record)) {
-      if (!is.logical(no_record)) {
-        stop(call. = FALSE, "`no_record` must be a logical vector.")
-      } else if (length(no_record) > 1) {
-        stop(call. = FALSE, "`no_record` must be a vector of length one.")
-      }
-    }
+    oc_check_logical(abbrv)
 
-    # check abbrv
-    if (!is.null(abbrv)) {
-      if (!is.logical(abbrv)) {
-        stop(call. = FALSE, "`abbrv` must be a logical vector.")
-      }
-    }
+    oc_check_logical(add_request)
 
-    # check add_request
-    if (!is.null(add_request)) {
-      if (!is.logical(add_request)) {
-        stop(call. = FALSE, "`add_request` must be a logical vector.")
-      }
-    }
   }

--- a/R/oc_config.R
+++ b/R/oc_config.R
@@ -7,6 +7,10 @@
 #' @param rate_sec Numeric vector of length one. Sets the maximum number of
 #'   requests sent to the OpenCage API per second. Defaults to the value set in
 #'   the \code{oc_rate_sec} option, or, in case that does not exist, to 1L.
+#' @param no_record Logical vector of length one. When \code{TRUE} OpenCage will
+#'   not create log entries of the queries and will not cache the geocoding
+#'   requests. Defaults to the value set in the \code{oc_no_record} option, or,
+#'   in case that does not exist, to FALSE.
 #' @param ... Ignored.
 #'
 #' @section Set your OpenCage API key:
@@ -27,7 +31,10 @@
 #' OpenCage API, so you do not even have to call \code{oc_config} to set your
 #' key, but can start geocoding right away. If you have the \pkg{usethis}
 #' package installed, you can edit your \code{\link[base:Startup]{.Renviron}}
-#' most easily with \code{usethis::edit_r_environ()}.
+#' most easily with \code{usethis::edit_r_environ()}. We strongly recommend
+#' storing your API key in the user-level .Renviron, as opposed to the
+#' project-level, because this makes it less likely you will share sensitive
+#' information by mistake.
 # nolint end
 #'
 #' 2. If you use a package like \pkg{keyring} to store your credentials, you can
@@ -50,11 +57,46 @@
 #' package installed, you can edit your \code{\link[base:Startup]{.Rprofile}}
 #' most easily with \code{usethis::edit_r_profile()}.
 #'
+#' @section Prevent query logging and caching:
+#'
+#' By default, OpenCage will store your queries in its server logs and will
+#' cache the forward geocoding requests on their side. They do this in order to
+#' speed up response times and to be able to debug errors and improve their
+#' service. Logs are automatically deleted after six months according to
+#' OpenCage's \href{https://opencagedata.com/gdpr}{page on data protection and
+#' GDPR}.
+#'
+#' If you set \code{no_record} to \code{TRUE}, the query contents are not logged
+#' nor cached. OpenCage still records that you made a request, but not the
+#' specific query you made. Please set \code{no_record} to \code{TRUE} if you
+#' have concerns about privacy and want OpenCage to have no record of your
+#' query.
+#'
+#' \code{oc_config} sets the \code{oc_no_record} \link[base:options]{option} for
+#' the active R session, so it will be used for all subsequent OpenCage queries.
+#' You can set the \code{oc_no_record} \link[base:options]{option} persistently
+#' across sessions in your \code{\link[base:Startup]{.Rprofile}}.
+#'
+#' Please note that the \pkg{opencage} package always caches the data it
+#' receives from the OpenCage API, but only for as long as your R session is
+#' alive.
+#'
+# nolint start - link longer than 80 chars
+#' For more information on OpenCage's policies on privacy and data protection
+#' see \href{https://opencagedata.com/faq#legal}{their FAQs}, their
+#' \href{https://opencagedata.com/gdpr}{GDPR page}, and,
+#' for the \code{no_record} parameter, see the relevant
+#' \href{https://blog.opencagedata.com/post/145602604628/more-privacy-with-norecord-parameter}{blog
+#' post}.
+# nolint end
+#'
+#'
 #' @export
 oc_config <-
   function(
     key = Sys.getenv("OPENCAGE_KEY"),
     rate_sec = getOption("oc_rate_sec", default = 1L),
+    no_record = getOption("oc_no_record", default = FALSE),
     ...) {
 
     key_needed <-
@@ -86,4 +128,8 @@ oc_config <-
       oc_get_limited,
       ratelimitr::rate(n = rate_sec, period = 1L)
     )
+
+    # set no_record
+    oc_check_logical(no_record, check_length_one = TRUE)
+    options("oc_no_record" = no_record)
   }

--- a/R/oc_forward.R
+++ b/R/oc_forward.R
@@ -59,9 +59,6 @@
 #'   road and driving information. Default is \code{FALSE}.
 #' @param no_dedupe Logical vector (default \code{FALSE}), when \code{TRUE}
 #'   the results will not be deduplicated.
-#' @param no_record Logical vector of length one (default \code{FALSE}), when
-#'   \code{TRUE} no log entry of the query is created, and the geocoding
-#'   request is not cached by OpenCage.
 #' @param abbrv Logical vector (default \code{FALSE}), when \code{TRUE}
 #'   addresses in the \code{formatted} field of the results are abbreviated
 #'   (e.g. "Main St." instead of "Main Street").
@@ -144,7 +141,6 @@ oc_forward <-
            no_annotations = TRUE,
            roadinfo = FALSE,
            no_dedupe = FALSE,
-           no_record = FALSE,
            abbrv = FALSE,
            add_request = FALSE,
            ...) {
@@ -156,10 +152,6 @@ oc_forward <-
 
     # check return
     return <- match.arg(return)
-
-    # get & check key
-    key <- Sys.getenv("OPENCAGE_KEY")
-    oc_check_key(key)
 
     # check arguments
     oc_check_query(
@@ -173,7 +165,6 @@ oc_forward <-
       no_annotations = no_annotations,
       roadinfo = roadinfo,
       no_dedupe = no_dedupe,
-      no_record = no_record,
       abbrv = abbrv,
       add_request = add_request
     )
@@ -181,7 +172,6 @@ oc_forward <-
     oc_process(
       placename = placename,
       return = return,
-      key = key,
       bounds = bounds,
       proximity = proximity,
       countrycode = countrycode,
@@ -191,7 +181,6 @@ oc_forward <-
       no_annotations = no_annotations,
       roadinfo = roadinfo,
       no_dedupe = no_dedupe,
-      no_record = no_record,
       abbrv = abbrv,
       add_request = add_request
     )
@@ -203,7 +192,6 @@ oc_forward <-
 #' Forward geocoding from a placename variable to latitude and longitude
 #'   tuple(s).
 #'
-#' @inheritParams oc_forward
 #' @param data A data frame.
 # nolint start - link longer than 80 chars
 #' @param placename An unquoted variable name of a character vector with the
@@ -219,8 +207,7 @@ oc_forward <-
 #'   a new tibble.
 #' @param output A character vector of length one indicating whether only
 #'   latitude, longitude, and formatted address variables (\code{"short"}, the
-#'   default) should be returned or all variables (\code{"all"}) variables
-#'   should be returned.
+#'   default), or all variables (\code{"all"}) variables should be returned.
 #' @param bounds A list of length one, or an unquoted variable name of a list
 #'   column of bounding boxes. Bounding boxes are named numeric vectors, each
 #'   with 4 coordinates forming the south-west and north-east corners of the
@@ -312,7 +299,7 @@ oc_forward <-
 #'               bounds = oc_bbox(-5, 45, 15, 55))
 #'
 #' # oc_forward_df accepts unquoted column names for all
-#' # arguments except bind_cols, output, and no_record.
+#' # arguments except bind_cols and output.
 #' # This makes it possible to build up more detailed queries
 #' # through the data frame passed to the data argument.
 #'
@@ -368,7 +355,6 @@ oc_forward_df.data.frame <- # nolint - see lintr issue #223
            no_annotations = TRUE,
            roadinfo = FALSE,
            no_dedupe = FALSE,
-           no_record = FALSE,
            abbrv = FALSE,
            ...) {
 
@@ -413,7 +399,6 @@ oc_forward_df.data.frame <- # nolint - see lintr issue #223
         no_annotations = rlang::eval_tidy(no_annotations, data = data),
         roadinfo = rlang::eval_tidy(roadinfo, data = data),
         no_dedupe = rlang::eval_tidy(no_dedupe, data = data),
-        no_record = no_record,
         abbrv = rlang::eval_tidy(abbrv, data = data),
         add_request = add_request
       )
@@ -454,7 +439,6 @@ oc_forward_df.data.frame <- # nolint - see lintr issue #223
               no_annotations = !!no_annotations,
               roadinfo = !!roadinfo,
               no_dedupe = !!no_dedupe,
-              no_record = no_record,
               abbrv = !!abbrv,
               add_request = add_request
             )
@@ -508,7 +492,6 @@ oc_forward_df.character <-
            no_annotations = TRUE,
            roadinfo = FALSE,
            no_dedupe = FALSE,
-           no_record = FALSE,
            abbrv = FALSE,
            ...) {
     xdf <- tibble::tibble(placename = placename)
@@ -525,7 +508,6 @@ oc_forward_df.character <-
       min_confidence = min_confidence,
       no_annotations = no_annotations,
       no_dedupe = no_dedupe,
-      no_record = no_record,
       abbrv = abbrv
     )
   }

--- a/R/oc_process.R
+++ b/R/oc_process.R
@@ -27,7 +27,6 @@ oc_process <-
     placename = NULL,
     latitude = NULL,
     longitude = NULL,
-    key = NULL,
     return = "url_only",
     bounds = NULL,
     proximity = NULL,
@@ -38,10 +37,23 @@ oc_process <-
     no_annotations = TRUE,
     roadinfo = FALSE,
     no_dedupe = FALSE,
-    no_record = FALSE,
     abbrv = FALSE,
-    add_request = FALSE
+    add_request = FALSE,
+    get_key = TRUE
   ) {
+
+    if (get_key) {
+      # get & check key
+      key <- Sys.getenv("OPENCAGE_KEY")
+      oc_check_key(key)
+    } else {
+      key <- NULL
+    }
+
+    # get & check no_record
+    no_record <- getOption("oc_no_record", default = FALSE)
+    oc_check_logical(no_record, check_length_one = TRUE)
+
     if (length(placename) > 1) {
       pb <- oc_init_progress(placename)
     } else if (length(latitude) > 1) {

--- a/R/oc_reverse.R
+++ b/R/oc_reverse.R
@@ -138,7 +138,7 @@ oc_reverse <-
 #'               language = "fr")
 #'
 #' # oc_reverse_df accepts unquoted column names for all
-#' # arguments except bind_cols, and output.
+#' # arguments except bind_cols and output.
 #' # This makes it possible to build up more detailed queries
 #' # through the data frame passed to the data argument.
 #'

--- a/R/oc_reverse.R
+++ b/R/oc_reverse.R
@@ -56,7 +56,6 @@ oc_reverse <-
            no_annotations = TRUE,
            roadinfo = FALSE,
            no_dedupe = FALSE,
-           no_record = FALSE,
            abbrv = FALSE,
            add_request = FALSE,
            ...) {
@@ -73,10 +72,6 @@ oc_reverse <-
     # check return
     return <- match.arg(return)
 
-    # get & check key
-    key <- Sys.getenv("OPENCAGE_KEY")
-    oc_check_key(key)
-
     # check arguments
     oc_check_query(
       latitude = latitude,
@@ -86,7 +81,6 @@ oc_reverse <-
       no_annotations = no_annotations,
       roadinfo = roadinfo,
       no_dedupe = no_dedupe,
-      no_record = no_record,
       abbrv = abbrv,
       add_request = add_request
     )
@@ -95,13 +89,11 @@ oc_reverse <-
       latitude = latitude,
       longitude = longitude,
       return = return,
-      key = key,
       language = language,
       min_confidence = min_confidence,
       no_annotations = no_annotations,
       roadinfo = roadinfo,
       no_dedupe = no_dedupe,
-      no_record = no_record,
       abbrv = abbrv,
       add_request = add_request
     )
@@ -113,9 +105,9 @@ oc_reverse <-
 #' @inheritParams oc_forward_df
 #' @param latitude,longitude Unquoted variable names of numeric vectors of
 #'   latitude and longitude values.
-#' @param output A character vector of length one indicating whether only
-#'   the formatted address (\code{"short"}, the default) should be returned or
-#'   all variables (\code{"all"}) variables should be returned.
+#' @param output A character vector of length one indicating whether only the
+#'   formatted address (\code{"short"}, the default) or all variables
+#'   (\code{"all"}) variables should be returned.
 #'
 #' @return A tibble. Column names coming from the OpenCage API are prefixed with
 #'   \code{"oc_"}.
@@ -146,7 +138,7 @@ oc_reverse <-
 #'               language = "fr")
 #'
 #' # oc_reverse_df accepts unquoted column names for all
-#' # arguments except bind_cols, output, and no_record.
+#' # arguments except bind_cols, and output.
 #' # This makes it possible to build up more detailed queries
 #' # through the data frame passed to the data argument.
 #'
@@ -187,7 +179,6 @@ oc_reverse_df.data.frame <- # nolint - see lintr issue #223
            roadinfo = FALSE,
            no_annotations = TRUE,
            no_dedupe = FALSE,
-           no_record = FALSE,
            abbrv = FALSE,
            ...) {
 
@@ -226,7 +217,6 @@ oc_reverse_df.data.frame <- # nolint - see lintr issue #223
         no_annotations = rlang::eval_tidy(no_annotations, data = data),
         roadinfo = rlang::eval_tidy(roadinfo, data = data),
         no_dedupe = rlang::eval_tidy(no_dedupe, data = data),
-        no_record = no_record,
         abbrv = rlang::eval_tidy(abbrv, data = data),
         add_request = add_request
       )
@@ -252,7 +242,6 @@ oc_reverse_df.data.frame <- # nolint - see lintr issue #223
               no_annotations = !!no_annotations,
               roadinfo = !!roadinfo,
               no_dedupe = !!no_dedupe,
-              no_record = no_record,
               abbrv = !!abbrv,
               add_request = add_request
             )
@@ -298,7 +287,6 @@ oc_reverse_df.numeric <-
            min_confidence = NULL,
            no_annotations = TRUE,
            no_dedupe = FALSE,
-           no_record = FALSE,
            abbrv = FALSE,
            ...) {
     xdf <- tibble::tibble(latitude = latitude, longitude = longitude)
@@ -312,7 +300,6 @@ oc_reverse_df.numeric <-
       min_confidence = min_confidence,
       no_annotations = no_annotations,
       no_dedupe = no_dedupe,
-      no_record = no_record,
       abbrv = abbrv
     )
   }

--- a/man/oc_config.Rd
+++ b/man/oc_config.Rd
@@ -5,7 +5,8 @@
 \title{Configure settings}
 \usage{
 oc_config(key = Sys.getenv("OPENCAGE_KEY"),
-  rate_sec = getOption("oc_rate_sec", default = 1L), ...)
+  rate_sec = getOption("oc_rate_sec", default = 1L),
+  no_record = getOption("oc_no_record", default = FALSE), ...)
 }
 \arguments{
 \item{key}{Your OpenCage API key as a character vector of length one. Do not
@@ -14,6 +15,11 @@ pass the key directly as a parameter, though. See details.}
 \item{rate_sec}{Numeric vector of length one. Sets the maximum number of
 requests sent to the OpenCage API per second. Defaults to the value set in
 the \code{oc_rate_sec} option, or, in case that does not exist, to 1L.}
+
+\item{no_record}{Logical vector of length one. When \code{TRUE} OpenCage will
+not create log entries of the queries and will not cache the geocoding
+requests. Defaults to the value set in the \code{oc_no_record} option, or,
+in case that does not exist, to FALSE.}
 
 \item{...}{Ignored.}
 }
@@ -38,7 +44,10 @@ R Programming}. From there it will be fetched by all functions that call the
 OpenCage API, so you do not even have to call \code{oc_config} to set your
 key, but can start geocoding right away. If you have the \pkg{usethis}
 package installed, you can edit your \code{\link[base:Startup]{.Renviron}}
-most easily with \code{usethis::edit_r_environ()}.
+most easily with \code{usethis::edit_r_environ()}. We strongly recommend
+storing your API key in the user-level .Renviron, as opposed to the
+project-level, because this makes it less likely you will share sensitive
+information by mistake.
 
 2. If you use a package like \pkg{keyring} to store your credentials, you can
 safely pass your key in a script with a function call like this
@@ -61,5 +70,38 @@ setting the \code{oc_rate_sec} \link[base:options]{option} in your
 \code{\link[base:Startup]{.Rprofile}}. If you have the \code{usethis}
 package installed, you can edit your \code{\link[base:Startup]{.Rprofile}}
 most easily with \code{usethis::edit_r_profile()}.
+}
+
+\section{Prevent query logging and caching}{
+
+
+By default, OpenCage will store your queries in its server logs and will
+cache the forward geocoding requests on their side. They do this in order to
+speed up response times and to be able to debug errors and improve their
+service. Logs are automatically deleted after six months according to
+OpenCage's \href{https://opencagedata.com/gdpr}{page on data protection and
+GDPR}.
+
+If you set \code{no_record} to \code{TRUE}, the query contents are not logged
+nor cached. OpenCage still records that you made a request, but not the
+specific query you made. Please set \code{no_record} to \code{TRUE} if you
+have concerns about privacy and want OpenCage to have no record of your
+query.
+
+\code{oc_config} sets the \code{oc_no_record} \link[base:options]{option} for
+the active R session, so it will be used for all subsequent OpenCage queries.
+You can set the \code{oc_no_record} \link[base:options]{option} persistently
+across sessions in your \code{\link[base:Startup]{.Rprofile}}.
+
+Please note that the \pkg{opencage} package always caches the data it
+receives from the OpenCage API, but only for as long as your R session is
+alive.
+
+For more information on OpenCage's policies on privacy and data protection
+see \href{https://opencagedata.com/faq#legal}{their FAQs}, their
+\href{https://opencagedata.com/gdpr}{GDPR page}, and,
+for the \code{no_record} parameter, see the relevant
+\href{https://blog.opencagedata.com/post/145602604628/more-privacy-with-norecord-parameter}{blog
+post}.
 }
 

--- a/man/oc_forward.Rd
+++ b/man/oc_forward.Rd
@@ -8,7 +8,7 @@ oc_forward(placename, return = c("df_list", "json_list", "geojson_list",
   "url_only"), bounds = NULL, proximity = NULL, countrycode = NULL,
   language = NULL, limit = 10L, min_confidence = NULL,
   no_annotations = TRUE, roadinfo = FALSE, no_dedupe = FALSE,
-  no_record = FALSE, abbrv = FALSE, add_request = FALSE, ...)
+  abbrv = FALSE, add_request = FALSE, ...)
 }
 \arguments{
 \item{placename}{A character vector with the placename(s) to be geocoded.
@@ -75,10 +75,6 @@ road and driving information. Default is \code{FALSE}.}
 
 \item{no_dedupe}{Logical vector (default \code{FALSE}), when \code{TRUE}
 the results will not be deduplicated.}
-
-\item{no_record}{Logical vector of length one (default \code{FALSE}), when
-\code{TRUE} no log entry of the query is created, and the geocoding
-request is not cached by OpenCage.}
 
 \item{abbrv}{Logical vector (default \code{FALSE}), when \code{TRUE}
 addresses in the \code{formatted} field of the results are abbreviated

--- a/man/oc_forward_df.Rd
+++ b/man/oc_forward_df.Rd
@@ -12,13 +12,12 @@ oc_forward_df(...)
   output = c("short", "all"), bounds = NULL, proximity = NULL,
   countrycode = NULL, language = NULL, limit = 1L,
   min_confidence = NULL, no_annotations = TRUE, roadinfo = FALSE,
-  no_dedupe = FALSE, no_record = FALSE, abbrv = FALSE, ...)
+  no_dedupe = FALSE, abbrv = FALSE, ...)
 
 \method{oc_forward_df}{character}(placename, output = c("short", "all"),
   bounds = NULL, proximity = NULL, countrycode = NULL, language = NULL,
   limit = 1L, min_confidence = NULL, no_annotations = TRUE,
-  roadinfo = FALSE, no_dedupe = FALSE, no_record = FALSE, abbrv = FALSE,
-  ...)
+  roadinfo = FALSE, no_dedupe = FALSE, abbrv = FALSE, ...)
 }
 \arguments{
 \item{...}{Ignored.}
@@ -39,8 +38,7 @@ a new tibble.}
 
 \item{output}{A character vector of length one indicating whether only
 latitude, longitude, and formatted address variables (\code{"short"}, the
-default) should be returned or all variables (\code{"all"}) variables
-should be returned.}
+default), or all variables (\code{"all"}) variables should be returned.}
 
 \item{bounds}{A list of length one, or an unquoted variable name of a list
 column of bounding boxes. Bounding boxes are named numeric vectors, each
@@ -102,10 +100,6 @@ information. Default is \code{FALSE}.}
 vector. Default is \code{FALSE}. When \code{TRUE} the results will not be
 deduplicated.}
 
-\item{no_record}{Logical vector of length one (default \code{FALSE}), when
-\code{TRUE} no log entry of the query is created, and the geocoding
-request is not cached by OpenCage.}
-
 \item{abbrv}{Logical vector, or an unquoted variable name of such a vector.
 Default is \code{FALSE}. When \code{TRUE} addresses in the
 \code{oc_formatted} variable of the results are abbreviated (e.g. "Main
@@ -143,7 +137,7 @@ oc_forward_df(df, placename = locations,
               bounds = oc_bbox(-5, 45, 15, 55))
 
 # oc_forward_df accepts unquoted column names for all
-# arguments except bind_cols, output, and no_record.
+# arguments except bind_cols and output.
 # This makes it possible to build up more detailed queries
 # through the data frame passed to the data argument.
 

--- a/man/oc_reverse.Rd
+++ b/man/oc_reverse.Rd
@@ -7,7 +7,7 @@
 oc_reverse(latitude, longitude, return = c("df_list", "json_list",
   "geojson_list", "url_only"), language = NULL, min_confidence = NULL,
   no_annotations = TRUE, roadinfo = FALSE, no_dedupe = FALSE,
-  no_record = FALSE, abbrv = FALSE, add_request = FALSE, ...)
+  abbrv = FALSE, add_request = FALSE, ...)
 }
 \arguments{
 \item{latitude, longitude}{Numeric vectors of latitude and longitude values.}
@@ -44,10 +44,6 @@ road and driving information. Default is \code{FALSE}.}
 
 \item{no_dedupe}{Logical vector (default \code{FALSE}), when \code{TRUE}
 the results will not be deduplicated.}
-
-\item{no_record}{Logical vector of length one (default \code{FALSE}), when
-\code{TRUE} no log entry of the query is created, and the geocoding
-request is not cached by OpenCage.}
 
 \item{abbrv}{Logical vector (default \code{FALSE}), when \code{TRUE}
 addresses in the \code{formatted} field of the results are abbreviated

--- a/man/oc_reverse_df.Rd
+++ b/man/oc_reverse_df.Rd
@@ -11,11 +11,11 @@ oc_reverse_df(...)
 \method{oc_reverse_df}{data.frame}(data, latitude, longitude,
   bind_cols = TRUE, output = c("short", "all"), language = NULL,
   min_confidence = NULL, roadinfo = FALSE, no_annotations = TRUE,
-  no_dedupe = FALSE, no_record = FALSE, abbrv = FALSE, ...)
+  no_dedupe = FALSE, abbrv = FALSE, ...)
 
 \method{oc_reverse_df}{numeric}(latitude, longitude, output = c("short",
   "all"), language = NULL, min_confidence = NULL, no_annotations = TRUE,
-  no_dedupe = FALSE, no_record = FALSE, abbrv = FALSE, ...)
+  no_dedupe = FALSE, abbrv = FALSE, ...)
 }
 \arguments{
 \item{...}{Ignored.}
@@ -29,9 +29,9 @@ latitude and longitude values.}
 column bound to \code{data}. When \code{FALSE}, the results are returned as
 a new tibble.}
 
-\item{output}{A character vector of length one indicating whether only
-the formatted address (\code{"short"}, the default) should be returned or
-all variables (\code{"all"}) variables should be returned.}
+\item{output}{A character vector of length one indicating whether only the
+formatted address (\code{"short"}, the default) or all variables
+(\code{"all"}) variables should be returned.}
 
 \item{language}{Character vector, or an unquoted variable name of such a
 vector, of \href{https://en.wikipedia.org/wiki/IETF_language_tag}{IETF BCP
@@ -65,10 +65,6 @@ will not contain annotations.}
 vector. Default is \code{FALSE}. When \code{TRUE} the results will not be
 deduplicated.}
 
-\item{no_record}{Logical vector of length one (default \code{FALSE}), when
-\code{TRUE} no log entry of the query is created, and the geocoding
-request is not cached by OpenCage.}
-
 \item{abbrv}{Logical vector, or an unquoted variable name of such a vector.
 Default is \code{FALSE}. When \code{TRUE} addresses in the
 \code{oc_formatted} variable of the results are abbreviated (e.g. "Main
@@ -100,7 +96,7 @@ oc_reverse_df(df, latitude = lat, longitude = lng,
               language = "fr")
 
 # oc_reverse_df accepts unquoted column names for all
-# arguments except bind_cols, output, and no_record.
+# arguments except bind_cols, and output.
 # This makes it possible to build up more detailed queries
 # through the data frame passed to the data argument.
 

--- a/man/oc_reverse_df.Rd
+++ b/man/oc_reverse_df.Rd
@@ -96,7 +96,7 @@ oc_reverse_df(df, latitude = lat, longitude = lng,
               language = "fr")
 
 # oc_reverse_df accepts unquoted column names for all
-# arguments except bind_cols, and output.
+# arguments except bind_cols and output.
 # This makes it possible to build up more detailed queries
 # through the data frame passed to the data argument.
 

--- a/tests/testthat/test-oc_check_query.R
+++ b/tests/testthat/test-oc_check_query.R
@@ -208,23 +208,6 @@ test_that("oc_check_query checks no_dedupe", {
   )
 })
 
-test_that("oc_check_query checks no_record", {
-  expect_error(
-    oc_check_query(
-      placename = "Sarzeau",
-      no_record = "yes"
-    ),
-    "`no_record` must be a logical vector."
-  )
-  expect_error(
-    oc_check_query(
-      placename = c("Sarzeau", "Nancy"),
-      no_record = c(TRUE, FALSE)
-    ),
-    "`no_record` must be a vector of length one."
-  )
-})
-
 test_that("oc_check_query checks abbrv", {
   expect_error(
     oc_check_query(
@@ -252,5 +235,35 @@ test_that("oc_check_query checks argument lengths", {
       abbrv = c(TRUE, FALSE)
     ),
     "same length as `placename` or `latitude`"
+  )
+})
+
+
+# Test oc_check_logical() -------------------------------------------------
+test_that("oc_check_logical checks no_record", {
+  no_record <- "yes"
+  expect_error(
+    oc_check_logical(
+      variable = no_record,
+      check_length_one = TRUE
+    ),
+    "`no_record` must be a logical vector."
+  )
+
+  no_record <- c(TRUE, FALSE)
+  expect_error(
+    oc_check_logical(
+      variable = no_record,
+      check_length_one = TRUE
+    ),
+    "`no_record` must be a vector of length one."
+  )
+
+  no_record <- TRUE
+  expect_silent(
+    oc_check_logical(
+      variable = no_record,
+      check_length_one = TRUE
+    )
   )
 })

--- a/tests/testthat/test-oc_check_status.R
+++ b/tests/testthat/test-oc_check_status.R
@@ -20,7 +20,6 @@ test_that("oc_check_status returns 400 error if request is invalid", {
     oc_process(
       latitude = 280,
       longitude = 0,
-      key = Sys.getenv("OPENCAGE_KEY"),
       return = "json_list"
     ),
     "HTTP failure: 400"
@@ -29,7 +28,6 @@ test_that("oc_check_status returns 400 error if request is invalid", {
   expect_error(
     oc_process(
       placename = "",
-      key = Sys.getenv("OPENCAGE_KEY"),
       return = "json_list"
     ),
     "HTTP failure: 400"

--- a/tests/testthat/test-oc_config.R
+++ b/tests/testthat/test-oc_config.R
@@ -35,7 +35,7 @@ test_that("oc_config throws error with faulty OpenCage key", {
 })
 
 
-# test rate_sec argument
+# test rate_sec argument --------------------------------------------------
 
 timer <- function(expr) {
   system.time(expr)[["elapsed"]]
@@ -64,4 +64,28 @@ test_that("oc_config updates rate limit of oc_get_limit", {
   t <- timer(oc_get_limited_test(rps + 1))
   expect_gt(t, 1)
   expect_lt(t, 2)
+})
+
+
+# test no_record argument -------------------------------------------------
+
+test_that("oc_config sets no_record", {
+
+  # Default without envvar and oc_config: no_record = FALSE
+  withr::local_options(list(oc_no_record = NULL))
+  res <- oc_process("Hamburg", return = "url_only", get_key = FALSE)
+  expect_match(res[[1]], "&no_record=0", fixed = TRUE)
+
+  # Default with oc_config: no_record = FALSE
+  oc_config()
+  expect_equal(getOption("oc_no_record"), FALSE)
+  res <- oc_process("Hamburg", return = "url_only", get_key = FALSE)
+  expect_match(res[[1]], "&no_record=0", fixed = TRUE)
+
+  # oc_config sets no_record = TRUE
+  oc_config(no_record = TRUE)
+  expect_equal(getOption("oc_no_record"), TRUE)
+  res <- oc_process("Hamburg", return = "url_only", get_key = FALSE)
+  expect_match(res[[1]], "&no_record=1", fixed = TRUE)
+
 })


### PR DESCRIPTION
Like I briefly mentioned in #99, I see `no_record` as a per-session setting rather than a per-request setting, i.e. if you want OpenCage to have no record of the contents of one of your queries, it is quite likely that you want that for your other queries, too. And if you don't and you want to change that during one session, you can still do so by running `oc_setup()`. Note also that `no_record` was one of the few arguments that were not vectorised in #67. 

This also introduces an `oc_check_logical()` function to streamline the checks of logical arguments in `oc_check_query`, and moves the handling of `key` and `no_record` from `oc_forward()`/`or_reverse()` to `oc_process()` (the `get_key` argument is only necessary for tests with and without API key). 