### PR TITLE
avoid build-time dependencies (#103, closes #96)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -103,19 +103,6 @@ oc_get <- function(oc_url) {
   client$get()
 }
 
-# limit requests per second
-oc_get_limited <-
-  ratelimitr::limit_rate(
-    oc_get,
-    # rate can be changed via oc_config()/ratelimitr::UPDATE_RATE()
-    ratelimitr::rate(
-      n = 1L,
-      period = 1L
-    )
-  )
-
-oc_get_memoise <- memoise::memoise(oc_get_limited)
-
 # initialise progress bar
 oc_init_progress <- function(vec) {
   progress::progress_bar$new(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,27 @@
+
+# Prevent build-time dependencies on {ratelimitr} and {memoise}
+# The functions do not get ratelimited/memoised at build-time, but when the
+# package is loaded.
+# cf. https://github.com/r-lib/memoise/issues/76
+
+# First make sure that the functions are defined at build time
+oc_get_limited <- oc_get
+oc_get_memoise <- oc_get_limited
+
+# Then modify them at load-time
+# nocov start
+.onLoad <- function(libname, pkgname) { # nolint because snake_case
+  # limit requests per second
+  oc_get_limited <<-
+    ratelimitr::limit_rate(
+      oc_get,
+      # rate can be changed via oc_config()/ratelimitr::UPDATE_RATE()
+      ratelimitr::rate(
+        n = 1L,
+        period = 1L
+      )
+    )
+
+  oc_get_memoise <<- memoise::memoise(oc_get_limited)
+}
+# nocov end


### PR DESCRIPTION
This PR prevents build-time dependencies on {memoise} and {ratelimitr}, closes #96.