### PR TITLE
test whether oc_config() requests key from terminal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
     tidyr (>= 0.8.0)
 Suggests: 
     knitr (>= 1.19),
+    mockery,
     rmarkdown (>= 1.8),
     sf (>= 0.9),
     testthat (>= 2.1.0),

--- a/R/oc_config.R
+++ b/R/oc_config.R
@@ -99,7 +99,7 @@ oc_config <-
 
     if (!identical(key, "")) {
       pat <- key
-    } else if (!interactive()) {
+    } else if (!rlang::is_interactive()) {
       stop(
         key_needed,
         "Please set the environment variable OPENCAGE_KEY to your OpenCage API key.", # nolint

--- a/tests/testthat/test-oc_config.R
+++ b/tests/testthat/test-oc_config.R
@@ -18,6 +18,21 @@ test_that("oc_config sets OPENCAGE_KEY environment variable", {
   expect_equal(Sys.getenv("OPENCAGE_KEY"), key_200)
 })
 
+test_that("oc_config requests key from terminal", {
+  rlang::local_interactive(TRUE)
+  withr::local_envvar(c("OPENCAGE_KEY" = ""))
+  mockery::stub(
+    oc_config,
+    'readline',
+    key_200,
+  )
+  expect_message(
+    oc_config(key = ""),
+    "Please enter your OpenCage API key and press enter:"
+  )
+  expect_equal(Sys.getenv("OPENCAGE_KEY"), key_200)
+})
+
 test_that("oc_config throws error with faulty OpenCage key", {
 
   # unset key


### PR DESCRIPTION
This adds a test for whether `oc_config()` requests a key via the terminal, if it is not provided otherwise.

For this we need to add {mockery} to Suggests. Not sure whether the additional dependency is worth it, though. 