### PR TITLE
fix tests without API key

### DIFF
--- a/R/oc_key.R
+++ b/R/oc_key.R
@@ -39,11 +39,15 @@ oc_check_key <- function(key) {
 #' @noRd
 
 oc_mask_key <- function(string) {
-  gsub(
-    x = string,
-    pattern = Sys.getenv("OPENCAGE_KEY"),
-    replacement = "OPENCAGE_KEY"
-  )
+  if (oc_key_present()) {
+    gsub(
+      x = string,
+      pattern = Sys.getenv("OPENCAGE_KEY"),
+      replacement = "OPENCAGE_KEY"
+    )
+  } else {
+    return(string)
+  }
 }
 
 #' Is an OpenCage API key present?

--- a/tests/testthat/helper-opencage.R
+++ b/tests/testthat/helper-opencage.R
@@ -14,6 +14,7 @@ skip_if_oc_offline <- function(host = "api.opencagedata.com") {
 skip_if_no_key <- function() {
   testthat::skip_if_not(
     condition = oc_key_present(),
+    # re message see https://github.com/r-lib/testthat/issues/1247
     message = "OpenCage API key is missing"
   )
 }

--- a/tests/testthat/test-oc_check_status.R
+++ b/tests/testthat/test-oc_check_status.R
@@ -12,7 +12,7 @@ test_that("oc_check_status returns no error if HTTP status 200", {
 })
 
 test_that("oc_check_status returns 400 error if request is invalid", {
-  skip_on_cran()
+  skip_if_no_key()
   skip_if_oc_offline()
 
   # Both shouldn't happen since we oc_check_query

--- a/tests/testthat/test-oc_config.R
+++ b/tests/testthat/test-oc_config.R
@@ -64,8 +64,9 @@ oc_get_limited_test <- function(reps) {
 }
 
 test_that("oc_config updates rate limit of oc_get_limit", {
-  skip_on_cran()
   skip_if_offline("httpbin.org")
+  # make sure there is a key present
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
 
   rps <- 5L
   oc_config(rate_sec = rps)
@@ -84,8 +85,10 @@ test_that("oc_config updates rate limit of oc_get_limit", {
 # test no_record argument -------------------------------------------------
 
 test_that("oc_config sets no_record option", {
+  # make sure there is a key present
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
 
-  # Default without envvar and oc_config(no_record = FALSE)
+  # Default without envvar set and oc_config(no_record = FALSE)
   withr::local_options(list(oc_no_record = NULL))
   res <- oc_process("Hamburg", return = "url_only")
   expect_match(res[[1]], "&no_record=0", fixed = TRUE)
@@ -107,6 +110,8 @@ test_that("oc_config sets no_record option", {
 # test show_key argument --------------------------------------------------
 
 test_that("oc_config sets show_key option", {
+  # make sure there is a key present
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
 
   # Default with oc_config(show_key = FALSE)
   oc_config()

--- a/tests/testthat/test-oc_key.R
+++ b/tests/testthat/test-oc_key.R
@@ -32,6 +32,15 @@ test_that("oc_mask_key masks key", {
   expect_match(oc_mask_key(key_200), "OPENCAGE_KEY", fixed = TRUE)
 })
 
+test_that("oc_mask_key does nothing if no key present", {
+  withr::local_envvar(c("OPENCAGE_KEY" = ""))
+  expect_match(
+    oc_mask_key("no_key_available"),
+    "no_key_available",
+    fixed = TRUE
+  )
+})
+
 ## Test oc_key_present ##
 
 test_that("oc_key_present detects if key is present", {


### PR DESCRIPTION
Fixed `oc_mask_key()` and some tests that did not work when no OPENCAGE_KEY envvar was present.