### PR TITLE
avoid side effects in opencage_* functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,14 +28,14 @@ Imports:
     ratelimitr (>= 0.4.0),
     rlang,
     tibble (>= 1.4.2),
-    tidyr (>= 0.8.0)
+    tidyr (>= 0.8.0),
+    withr (>= 2.0.0)
 Suggests: 
     knitr (>= 1.19),
     mockery,
     rmarkdown (>= 1.8),
     sf (>= 0.9),
-    testthat (>= 2.1.0),
-    withr (>= 2.0.0)
+    testthat (>= 2.1.0)
 VignetteBuilder: knitr
 Encoding: UTF-8
 Language: en-GB

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -68,7 +68,10 @@ opencage_forward <-
 
     lifecycle::deprecate_soft("0.2.0", "opencage_forward()", "oc_forward()")
 
-    oc_config(key = key, no_record = no_record)
+    # set key and no_record option locally,
+    # i.e. go back to default after function is finished
+    withr::local_envvar(list("OPENCAGE_KEY" = key))
+    withr::local_options(list(oc_no_record = no_record))
 
     lst <- oc_forward(
       placename = placename,
@@ -136,7 +139,10 @@ opencage_reverse <-
 
     lifecycle::deprecate_soft("0.2.0", "opencage_reverse()", "oc_reverse()")
 
-    oc_config(key = key, no_record = no_record)
+    # set key and no_record option locally,
+    # i.e. go back to default after function is finished
+    withr::local_envvar(list("OPENCAGE_KEY" = key))
+    withr::local_options(list(oc_no_record = no_record))
 
     lst <- oc_reverse(
       latitude = latitude,


### PR DESCRIPTION
The deprecated `opencage_*` functions created side effects due to them calling `oc_config()`. I.e. the environment variables and options set by `oc_config()` stayed in place. 

Now we set the necessary envvars and options with {withr}.