### PR TITLE
add package version to user-agent string

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: opencage
 Title: Geocode with the OpenCage API
-Version: 0.1.4.9006
+Version: 0.1.4.9007
 Authors@R: c(
     person("Maëlle", "Salmon", email = "maelle.salmon@yahoo.se", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2815-0399")), 
     person("Daniel", "Possenriede", role = "aut", comment = c(ORCID = "0000-0002-6738-9845")),

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,10 +102,19 @@ oc_build_url <- function(query_par, endpoint) {
 }
 
 # get results
+
+# user-agent string: this is set at build-time, but that should be okay,
+# since the version number is too.
+oc_ua_string <-
+  paste0(
+    "<https://github.com/ropensci/opencage>, version ",
+    packageVersion("opencage")
+  )
+
 oc_get <- function(oc_url) {
   client <- crul::HttpClient$new(
     url = oc_url,
-    headers = list(`User-Agent` = "https://github.com/ropensci/opencage")
+    headers = list(`User-Agent` = oc_ua_string)
   )
   client$get()
 }


### PR DESCRIPTION
closes #124 

oc_ua_string is set at build time, but this should be okay, since the version no. is set at build time as well. 