### PR TITLE
polish tests a bit

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,3 @@
 library(testthat)
-library(opencage)
 
 test_check("opencage")

--- a/tests/testthat/test-deprecated.R
+++ b/tests/testthat/test-deprecated.R
@@ -1,9 +1,7 @@
 ## Test deprecated opencage_forward ##
 
 test_that("opencage_forward/opencage_reverse return what they should.", {
-  skip_if_no_key()
-  skip_if_oc_offline()
-
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
   lifecycle::expect_deprecated(
     results <- opencage_forward(placename = "Sarzeau")
   )
@@ -14,32 +12,7 @@ test_that("opencage_forward/opencage_reverse return what they should.", {
   expect_equal(length(results), 4)
 
   lifecycle::expect_deprecated(
-    results <- opencage_forward(placename = "Islington, London")
-  )
-  expect_is(results, "list")
-  expect_is(results[["results"]], "tbl_df")
-  expect_is(results[["total_results"]], "integer")
-  expect_is(results[["time_stamp"]], "POSIXct")
-  expect_equal(length(results), 4)
-
-  placename <- "Triererstr 15, Weimar 99423, Deutschland"
-  lifecycle::expect_deprecated(
-    results <- opencage_forward(placename = placename)
-  )
-  expect_is(results, "list")
-  expect_is(results[["results"]], "tbl_df")
-  expect_is(results[["total_results"]], "integer")
-  expect_is(results[["time_stamp"]], "POSIXct")
-  expect_equal(length(results), 4)
-
-  lifecycle::expect_deprecated(
-    results <-
-      opencage_reverse(
-        longitude = 0,
-        latitude = 0,
-        limit = 2,
-        key = Sys.getenv("OPENCAGE_KEY")
-      )
+    results <- opencage_reverse(longitude = 0, latitude = 0)
   )
   expect_is(results, "list")
   expect_is(results[["results"]], "tbl_df")
@@ -50,13 +23,11 @@ test_that("opencage_forward/opencage_reverse return what they should.", {
 
 test_that("opencage_forward/opencage_reverse return what they should
           with several parameters.", {
-  skip_if_no_key()
-  skip_if_oc_offline()
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
 
   lifecycle::expect_deprecated(
     results <- opencage_forward(
       placename = "Paris",
-      key = Sys.getenv("OPENCAGE_KEY"),
       limit = 2,
       min_confidence = 5,
       language = "fr",
@@ -77,8 +48,6 @@ test_that("opencage_forward/opencage_reverse return what they should
     results <- opencage_reverse(
       latitude = 44,
       longitude = 44,
-      key = Sys.getenv("OPENCAGE_KEY"),
-      limit = 2,
       min_confidence = 5,
       language = "pt-BR",
       no_annotations = TRUE)
@@ -99,9 +68,11 @@ test_that("opencage_forward deals well with results being NULL", {
   skip_if_no_key()
   skip_if_oc_offline()
 
+  # the query NOWHERE-INTERESTING will return a valid response with 0 results
+  # https://opencagedata.com/api#no-results
   lifecycle::expect_deprecated(
     results <- opencage_forward(
-      placename = "thiswillgetmenoresultswichisgood",
+      placename = "NOWHERE-INTERESTING",
       key = Sys.getenv("OPENCAGE_KEY"),
       limit = 2,
       min_confidence = 5,
@@ -134,6 +105,8 @@ test_that("the bounds argument is well taken into account", {
 })
 
 test_that("Errors with multiple inputs", {
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
+
   expect_error(opencage_forward(c("Hamburg", "Los Angeles")),
     "`opencage_forward` is not vectorised; use `oc_forward` instead.")
   expect_error(opencage_reverse(c(5, 20), c(6, 21)),

--- a/tests/testthat/test-oc_config.R
+++ b/tests/testthat/test-oc_config.R
@@ -19,6 +19,7 @@ test_that("oc_config sets OPENCAGE_KEY environment variable", {
 })
 
 test_that("oc_config requests key from terminal", {
+  skip_if_not_installed("mockery")
   rlang::local_interactive(TRUE)
   withr::local_envvar(c("OPENCAGE_KEY" = ""))
   mockery::stub(

--- a/tests/testthat/test-oc_forward.R
+++ b/tests/testthat/test-oc_forward.R
@@ -66,11 +66,11 @@ test_that("oc_forward adds request with add_request", {
 })
 
 test_that("oc_forward masks key when add_request = TRUE", {
-  skip_if_no_key()
   skip_if_oc_offline()
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
 
   # json_list
-  res <- oc_forward("Hamburg", return = "json_list", add_request = TRUE)
+  res <- oc_forward("irrelevant", return = "json_list", add_request = TRUE)
   expect_equal(res[[1]][["request"]][["key"]], "OPENCAGE_KEY")
 })
 

--- a/tests/testthat/test-oc_get.R
+++ b/tests/testthat/test-oc_get.R
@@ -1,14 +1,14 @@
 ## Test oc_get ##
 
 test_that("oc_get returns a response object", {
-  skip_if_no_key()
   skip_if_oc_offline()
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
 
   expect_s3_class(
     oc_get(
       oc_build_url(
         query_par = list(
-          placename = "Sarzeau",
+          placename = "irrelevant",
           key = Sys.getenv("OPENCAGE_KEY")
         ),
         endpoint = "json"

--- a/tests/testthat/test-oc_process.R
+++ b/tests/testthat/test-oc_process.R
@@ -61,36 +61,6 @@ test_that("oc_process creates meaningful URLs for single query.", {
   expect_match(res[[1]], "q=41.40139%2C2.1287", fixed = TRUE)
 })
 
-test_that("oc_process creates meaningful URLs with NAs.", {
-  res <-
-    oc_process(
-      placename = NA_character_,
-      return = "url_only"
-    )
-  expect_match(res[[1]], "q=&", fixed = TRUE)
-  res <-
-    oc_process(
-      latitude = NA_real_,
-      longitude = NA_real_,
-      return = "url_only"
-    )
-  expect_match(res[[1]], "q=&", fixed = TRUE)
-  res <-
-    oc_process(
-      latitude = 0,
-      longitude = NA_real_,
-      return = "url_only"
-    )
-  expect_match(res[[1]], "q=&", fixed = TRUE)
-  res <-
-    oc_process(
-      latitude = NA_real_,
-      longitude = 0,
-      return = "url_only"
-    )
-  expect_match(res[[1]], "q=&", fixed = TRUE)
-})
-
 test_that("oc_process creates meaningful URLs for multiple queries.", {
   res <- oc_process(
     placename = c("Paris", "Hamburg"),

--- a/tests/testthat/test-oc_process.R
+++ b/tests/testthat/test-oc_process.R
@@ -23,6 +23,7 @@ test_that("oc_process(return = 'url_only') shows key if desired.", {
 })
 
 test_that("oc_process creates meaningful URLs for single query.", {
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
   res <-
     oc_process(
       placename = "Paris",
@@ -62,6 +63,7 @@ test_that("oc_process creates meaningful URLs for single query.", {
 })
 
 test_that("oc_process creates meaningful URLs for multiple queries.", {
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
   res <- oc_process(
     placename = c("Paris", "Hamburg"),
     return = "url_only"
@@ -83,6 +85,7 @@ test_that("oc_process creates meaningful URLs for multiple queries.", {
 })
 
 test_that("oc_process handles bounds argument.", {
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
   res <- oc_process(
     placename = "Sarzeau",
     bounds = list(c(-5.5, 51.2, 0.2, 51.6)),
@@ -132,6 +135,7 @@ test_that("bounds argument is well taken into account with df_list", {
 })
 
 test_that("oc_process handles proximity argument.", {
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
   res <- oc_process(
     placename = "Warsaw",
     proximity = list(c(latitude = 41.2, longitude = -85.8)),
@@ -159,6 +163,7 @@ test_that("oc_process handles proximity argument.", {
 })
 
 test_that("oc_process handles language argument.", {
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
   res1 <- oc_process(
     placename = c("New York", "Rio", "Tokyo"),
     language = "ja",
@@ -177,6 +182,7 @@ test_that("oc_process handles language argument.", {
 })
 
 test_that("oc_process handles countrycode argument.", {
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
   res1 <- oc_process(
     placename = c("Hamburg", "Paris"),
     countrycode = "DE",
@@ -203,6 +209,7 @@ test_that("oc_process handles countrycode argument.", {
 })
 
 test_that("oc_process handles various other arguments.", {
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
   res1 <- oc_process(
     placename = "Hamburg",
     return = "url_only",
@@ -269,6 +276,7 @@ test_that("oc_process handles various other arguments.", {
 })
 
 test_that("arguments that are NULL or NA don't show up in url.", {
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
   res_null <- oc_process(
     placename = "Hamburg",
     return = "url_only",

--- a/tests/testthat/test-oc_process.R
+++ b/tests/testthat/test-oc_process.R
@@ -82,21 +82,6 @@ test_that("oc_process creates meaningful URLs for multiple queries.", {
   expect_match(res[[2]], "q=37.83032%2C-122.47975", fixed = TRUE)
 })
 
-test_that("oc_process deals well with res being NULL", {
-  skip_if_no_key()
-  skip_if_oc_offline()
-
-  res <- oc_process(
-    placename = "thiswillgetmenoreswhichisgood",
-    limit = 2,
-    min_confidence = 5,
-    language = "pt-BR",
-    no_annotations = TRUE,
-    return = "df_list"
-  )
-  expect_null(res[["res"]])
-})
-
 test_that("oc_process handles bounds argument.", {
   res <- oc_process(
     placename = "Sarzeau",

--- a/tests/testthat/test-oc_reverse.R
+++ b/tests/testthat/test-oc_reverse.R
@@ -57,8 +57,8 @@ test_that("oc_reverse adds request with add_request", {
 })
 
 test_that("oc_reverse masks key when add_request = TRUE", {
-  skip_if_no_key()
   skip_if_oc_offline()
+  withr::local_envvar(c("OPENCAGE_KEY" = key_200))
 
   res <- oc_reverse(lat[1], lng[1], return = "json_list", add_request = TRUE)
   expect_equal(res[[1]][["request"]][["key"]], "OPENCAGE_KEY")


### PR DESCRIPTION
some small test changes

- do not (explicitly) load opencage in tests
- check if mockery is installed (because it is only in Suggests)
- remove unnecessary tests
- use OpenCage's 200 test key more often to reduce chance of leakage a little (and run more tests when no real key is present)