### PR TITLE
fix CRAN error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: opencage
 Title: Geocode with the OpenCage API
-Version: 0.2.1.9000
+Version: 0.2.2
 Authors@R: c(
     person("Daniel", "Possenriede", email = "possenriede+r@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6738-9845")),
     person("Jesse", "Sadler", role = "aut", comment = c(ORCID = "0000-0001-6081-9681")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# opencage (development version)
+# opencage 0.2.2
+
+* Fixed a test that caused an error on CRAN's Solaris (#131).
 
 # opencage 0.2.1
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ output:
 
 <!-- badges: end -->
 
-Geocode with the [OpenCage](https://opencagedata.com/) API, either from place name to longitude and latitude (forward geocoding) or from longitude and latitude to the name and address of the location (reverse geocoding). 
+Geocode with the [OpenCage](https://opencagedata.com) API, either from place name to longitude and latitude (forward geocoding) or from longitude and latitude to the name and address of the location (reverse geocoding). 
 
 ## Installation
 
@@ -27,7 +27,7 @@ Install the package with:
 install.packages("opencage")
 ```
 
-Or install the development version using [remotes](https://remotes.r-lib.org/) with:
+Or install the development version using [remotes](https://remotes.r-lib.org) with:
 
 ```{r, eval = FALSE}
 remotes::install_github("ropensci/opencage")
@@ -64,14 +64,14 @@ But remember, the vignettes are really great! We have:
 
 ## About OpenCage
 
-The [OpenCage](https://opencagedata.com/) API supports forward and reverse geocoding. 
+The [OpenCage](https://opencagedata.com) API supports forward and reverse geocoding. 
 Sources of OpenCage are open geospatial data including 
-[OpenStreetMap](https://www.openstreetmap.org/), 
+[OpenStreetMap](https://www.openstreetmap.org), 
 [DataScienceToolkit](https://github.com/petewarden/dstk), 
 [GeoPlanet](https://en.wikipedia.org/wiki/GeoPlanet), 
-[Natural Earth Data](https://www.naturalearthdata.com/), 
+[Natural Earth Data](https://www.naturalearthdata.com), 
 [libpostal](https://github.com/openvenues/libpostal), 
-[GeoNames](https://www.geonames.org/), and 
+[GeoNames](https://www.geonames.org), and 
 [Flickr's shapefiles](https://code.flickr.net/2009/05/21/flickr-shapefiles-public-dataset-10/) plus a whole lot more besides. 
 Refer to the current full [list of credits](https://opencagedata.com/credits).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Peer-Review](https://badges.ropensci.org/36_status.svg)](https://github.com/rope
 
 <!-- badges: end -->
 
-Geocode with the [OpenCage](https://opencagedata.com/) API, either from
+Geocode with the [OpenCage](https://opencagedata.com) API, either from
 place name to longitude and latitude (forward geocoding) or from
 longitude and latitude to the name and address of the location (reverse
 geocoding).
@@ -33,7 +33,7 @@ install.packages("opencage")
 ```
 
 Or install the development version using
-[remotes](https://remotes.r-lib.org/) with:
+[remotes](https://remotes.r-lib.org) with:
 
 ``` r
 remotes::install_github("ropensci/opencage")
@@ -86,14 +86,14 @@ But remember, the vignettes are really great! We have:
 
 ## About OpenCage
 
-The [OpenCage](https://opencagedata.com/) API supports forward and
+The [OpenCage](https://opencagedata.com) API supports forward and
 reverse geocoding. Sources of OpenCage are open geospatial data
-including [OpenStreetMap](https://www.openstreetmap.org/),
+including [OpenStreetMap](https://www.openstreetmap.org),
 [DataScienceToolkit](https://github.com/petewarden/dstk),
 [GeoPlanet](https://en.wikipedia.org/wiki/GeoPlanet), [Natural Earth
-Data](https://www.naturalearthdata.com/),
+Data](https://www.naturalearthdata.com),
 [libpostal](https://github.com/openvenues/libpostal),
-[GeoNames](https://www.geonames.org/), and [Flickr’s
+[GeoNames](https://www.geonames.org), and [Flickr’s
 shapefiles](https://code.flickr.net/2009/05/21/flickr-shapefiles-public-dataset-10/)
 plus a whole lot more besides. Refer to the current full [list of
 credits](https://opencagedata.com/credits).

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,16 +1,10 @@
 ## Release summary
 
-### v0.2.1
-* Fixed two URLs, one of which was rejected on the v0.2.0 submission.
-
-### v0.2.0 (unreleased)
-* Rewrite of the package, see NEWS.md for details.
-* Change of maintainer:
-  * New Maintainer: Daniel Possenriede <possenriede+r@gmail.com>
-  * Old maintainer: Maëlle Salmon <maelle.salmon@yahoo.se>
+### v0.2.2
+This patch version fixes a test that caused an error on CRAN's Solaris (<https://github.com/ropensci/opencage/pull/131>, <https://www.r-project.org/nosvn/R.check/r-patched-solaris-x86/opencage-00check.html>).
 
 ## Test environments
-* local x86_64-w64-mingw32/x64 install, R 4.0.3
+* local x86_64-w64-mingw32/x64, R 4.0.4
 * GitHub Actions <https://github.com/ropensci/opencage/actions?query=workflow%3AR-CMD-check>:
   * Ubuntu 20.04, R devel, release and oldrel
   * windows-latest, R release
@@ -21,17 +15,14 @@
   * Windows Server 2008 R2 SP1, R-devel, 32/64 bit
 * win-builder (devel)
 
-## R CMD check results
+## R CMD check results (local)
 
-Duration: 2m 1.9s
+Duration: 2m 10.8s
 
 > checking CRAN incoming feasibility ... NOTE
   Maintainer: 'Daniel Possenriede <possenriede+r@gmail.com>'
   
-  New maintainer:
-    Daniel Possenriede <possenriede+r@gmail.com>
-  Old maintainer(s):
-    Maëlle Salmon <maelle.salmon@yahoo.se>
+  Days since last update: 4
 
 0 errors √ | 0 warnings √ | 1 note x
 

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -2,7 +2,7 @@
 
 |field    |value                        |
 |:--------|:----------------------------|
-|version  |R version 4.0.3 (2020-10-10) |
+|version  |R version 4.0.4 (2021-02-15) |
 |os       |Windows 10 x64               |
 |system   |x86_64, mingw32              |
 |ui       |RStudio                      |
@@ -10,20 +10,19 @@
 |collate  |German_Germany.1252          |
 |ctype    |German_Germany.1252          |
 |tz       |Europe/Berlin                |
-|date     |2021-02-11                   |
+|date     |2021-02-18                   |
 
 # Dependencies
 
 |package     |old    |new    |<U+0394>  |
 |:-----------|:------|:------|:--|
-|opencage    |0.1.4  |0.2.0  |*  |
-|askpass     |1.1    |NA     |*  |
+|opencage    |0.2.1  |0.2.2  |*  |
 |assertthat  |0.2.1  |0.2.1  |   |
-|cachem      |1.0.3  |1.0.3  |   |
+|cachem      |1.0.4  |1.0.4  |   |
 |cli         |2.3.0  |2.3.0  |   |
-|cpp11       |NA     |0.2.6  |*  |
+|cpp11       |0.2.6  |0.2.6  |   |
 |crayon      |1.4.1  |1.4.1  |   |
-|crul        |NA     |1.0.0  |*  |
+|crul        |1.1.0  |1.1.0  |   |
 |curl        |4.3    |4.3    |   |
 |digest      |0.6.27 |0.6.27 |   |
 |dplyr       |1.0.4  |1.0.4  |   |
@@ -32,33 +31,30 @@
 |fastmap     |1.1.0  |1.1.0  |   |
 |generics    |0.1.0  |0.1.0  |   |
 |glue        |1.4.2  |1.4.2  |   |
-|hms         |NA     |1.0.0  |*  |
-|httpcode    |NA     |0.3.0  |*  |
-|httr        |1.4.2  |NA     |*  |
+|hms         |1.0.0  |1.0.0  |   |
+|httpcode    |0.3.0  |0.3.0  |   |
 |jsonlite    |1.7.2  |1.7.2  |   |
-|lifecycle   |0.2.0  |0.2.0  |   |
+|lifecycle   |1.0.0  |1.0.0  |   |
 |magrittr    |2.0.1  |2.0.1  |   |
 |memoise     |2.0.0  |2.0.0  |   |
-|mime        |0.9    |0.9    |   |
-|openssl     |1.4.3  |NA     |*  |
+|mime        |0.10   |0.10   |   |
 |pillar      |1.4.7  |1.4.7  |   |
 |pkgconfig   |2.0.3  |2.0.3  |   |
-|prettyunits |NA     |1.1.1  |*  |
-|progress    |NA     |1.2.2  |*  |
+|prettyunits |1.1.1  |1.1.1  |   |
+|progress    |1.2.2  |1.2.2  |   |
 |purrr       |0.3.4  |0.3.4  |   |
 |R6          |2.5.0  |2.5.0  |   |
-|ratelimitr  |NA     |0.4.1  |*  |
-|Rcpp        |NA     |1.0.6  |*  |
+|ratelimitr  |0.4.1  |0.4.1  |   |
+|Rcpp        |1.0.6  |1.0.6  |   |
 |rlang       |0.4.10 |0.4.10 |   |
-|sys         |3.4    |NA     |*  |
 |tibble      |3.0.6  |3.0.6  |   |
-|tidyr       |NA     |1.1.2  |*  |
+|tidyr       |1.1.2  |1.1.2  |   |
 |tidyselect  |1.1.0  |1.1.0  |   |
-|triebeard   |NA     |0.3.0  |*  |
-|urltools    |NA     |1.7.3  |*  |
+|triebeard   |0.3.0  |0.3.0  |   |
+|urltools    |1.7.3  |1.7.3  |   |
 |utf8        |1.1.4  |1.1.4  |   |
 |vctrs       |0.3.6  |0.3.6  |   |
-|withr       |NA     |2.4.1  |*  |
+|withr       |2.4.1  |2.4.1  |   |
 
 # Revdeps
 

--- a/vignettes/customise_query.Rmd
+++ b/vignettes/customise_query.Rmd
@@ -2,7 +2,7 @@
 title: "Customise your query"
 subtitle: "Get more and better results from OpenCage"
 author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
-date: "2021-02-11"
+date: "2021-02-18"
 description: >
   "The OpenCage API supports about a dozen parameters to customise a query and here we will explain how to use them."
 output:

--- a/vignettes/opencage.Rmd
+++ b/vignettes/opencage.Rmd
@@ -2,7 +2,7 @@
 title: "Introduction to opencage"
 subtitle: "Forward and Reverse Geocoding"
 author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
-date: "2021-02-14"
+date: "2021-02-18"
 description: >
   "Get started with the opencage R package to geocode with the OpenCage API, either from place name to longitude and latitude (forward geocoding) or from longitude and latitude to the name and address of a location (reverse geocoding)."
 output:
@@ -46,7 +46,7 @@ There are three safer ways to set your API key instead:
 From there it will be fetched by all functions that call the OpenCage API.
 You do not even have to call `oc_config()` to set your key;
 you can start geocoding right away.
-If you have the {[usethis](https://usethis.r-lib.org/)} package installed, you can edit your `.Renviron` with `usethis::edit_r_environ()`.
+If you have the {[usethis](https://usethis.r-lib.org)} package installed, you can edit your `.Renviron` with `usethis::edit_r_environ()`.
 We strongly recommend storing your API key in the user-level `.Renviron`, as opposed to the project-level.
 This makes it less likely you will share sensitive information by mistake.
 
@@ -66,7 +66,7 @@ If you have a "Free Trial" account with OpenCage, you can skip to the next secti
 
 If you have a paid account, you can set the rate limit for the active R session with `oc_config(rate_sec = n)` where `n` is the appropriate rate limit.
 You can set the rate limit persistently across sessions by setting an `oc_rate_sec` option in your `.Rprofile`.
-If you have the {[usethis](https://usethis.r-lib.org/)} package installed, you can edit your `.Rprofile` with `usethis::edit_r_profile()`.
+If you have the {[usethis](https://usethis.r-lib.org)} package installed, you can edit your `.Rprofile` with `usethis::edit_r_profile()`.
 
 ### Privacy
 
@@ -128,7 +128,7 @@ oc_forward_df(placename = opera)
 #>   placename               oc_lat oc_lng oc_formatted                                                                     
 #>   <chr>                    <dbl>  <dbl> <chr>                                                                            
 #> 1 Palacio de Bellas Artes   19.4 -99.1  Palacio de Bellas Artes, Avenida Juárez, Centro Urbano, 06050 Mexico City, Mexico
-#> 2 Scala                     45.5   9.19 Teatro alla Scala, Via Giuseppe Verdi, 20121 Milan Milan, Italy                  
+#> 2 Scala                     45.5   9.19 Teatro alla Scala, Largo Antonio Ghiringhelli, Milan Milan, Italy                
 #> 3 Sydney Opera House       -33.9 151.   Sydney Opera House, 2 Macquarie Street, Sydney NSW 2000, Australia
 ```
 
@@ -216,11 +216,11 @@ To minimize the number of requests sent to the API {opencage} uses {[memoise](ht
 ```r
 system.time(oc_reverse(latitude = 10, longitude = 10))
 #>    user  system elapsed 
-#>    0.00    0.00    0.81
+#>    0.03    0.00    0.92
 
 system.time(oc_reverse(latitude = 10, longitude = 10))
 #>    user  system elapsed 
-#>       0       0       0
+#>    0.01    0.00    0.02
 ```
 
 To clear the cache of all results either start a new R session or call `oc_clear_cache()`.
@@ -232,7 +232,7 @@ oc_clear_cache()
 
 system.time(oc_reverse(latitude = 10, longitude = 10))
 #>    user  system elapsed 
-#>    0.03    0.00    0.74
+#>    0.00    0.00    0.92
 ```
 
 As you probably know, cache invalidation is one of the harder things to do in computer science.
@@ -249,4 +249,4 @@ Besides `oc_forward_df()` and `oc_reverse_df()`, which always return a single ti
 Depending on what you specify as the `return` parameter, `oc_forward()` and `oc_reverse()` will return either a list of tibbles (`df_list`, the default), JSON lists (`json_list`), GeoJSON lists (`geojson_list`), or the URL with which the API would be called (`url_only`).
 Learn more in the ["Output options"](output_options.html) vignette.
 
-Please report any issues or bugs on [our GitHub repository](https://github.com/ropensci/opencage/issues) and post questions on [discuss.ropensci.org](https://discuss.ropensci.org/).
+Please report any issues or bugs on [our GitHub repository](https://github.com/ropensci/opencage/issues) and post questions on [discuss.ropensci.org](https://discuss.ropensci.org).

--- a/vignettes/opencage.Rmd.src
+++ b/vignettes/opencage.Rmd.src
@@ -54,7 +54,7 @@ There are three safer ways to set your API key instead:
 From there it will be fetched by all functions that call the OpenCage API.
 You do not even have to call `oc_config()` to set your key;
 you can start geocoding right away.
-If you have the {[usethis](https://usethis.r-lib.org/)} package installed, you can edit your `.Renviron` with `usethis::edit_r_environ()`.
+If you have the {[usethis](https://usethis.r-lib.org)} package installed, you can edit your `.Renviron` with `usethis::edit_r_environ()`.
 We strongly recommend storing your API key in the user-level `.Renviron`, as opposed to the project-level.
 This makes it less likely you will share sensitive information by mistake.
 
@@ -74,7 +74,7 @@ If you have a "Free Trial" account with OpenCage, you can skip to the next secti
 
 If you have a paid account, you can set the rate limit for the active R session with `oc_config(rate_sec = n)` where `n` is the appropriate rate limit.
 You can set the rate limit persistently across sessions by setting an `oc_rate_sec` option in your `.Rprofile`.
-If you have the {[usethis](https://usethis.r-lib.org/)} package installed, you can edit your `.Rprofile` with `usethis::edit_r_profile()`.
+If you have the {[usethis](https://usethis.r-lib.org)} package installed, you can edit your `.Rprofile` with `usethis::edit_r_profile()`.
 
 ### Privacy
 
@@ -210,4 +210,4 @@ Besides `oc_forward_df()` and `oc_reverse_df()`, which always return a single ti
 Depending on what you specify as the `return` parameter, `oc_forward()` and `oc_reverse()` will return either a list of tibbles (`df_list`, the default), JSON lists (`json_list`), GeoJSON lists (`geojson_list`), or the URL with which the API would be called (`url_only`).
 Learn more in the ["Output options"](output_options.html) vignette.
 
-Please report any issues or bugs on [our GitHub repository](https://github.com/ropensci/opencage/issues) and post questions on [discuss.ropensci.org](https://discuss.ropensci.org/).
+Please report any issues or bugs on [our GitHub repository](https://github.com/ropensci/opencage/issues) and post questions on [discuss.ropensci.org](https://discuss.ropensci.org).

--- a/vignettes/output_options.Rmd
+++ b/vignettes/output_options.Rmd
@@ -2,7 +2,7 @@
 title: "Output options"
 subtitle: "Get different kinds of output from OpenCage"
 author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
-date: "2021-02-13"
+date: "2021-02-18"
 description: >
   "`oc_forward()`/`oc_reverse()` return lists of various type, namely data frames, JSON, GeoJSON or URLs, depending on the `return` value you specify. The possible `return` values are `df_list`, `json_list`, `geojson_list` and `url_only`."
 output:
@@ -225,10 +225,10 @@ oc_forward("Casey Station", return = "json_list")
 #> 
 #> [[1]]$timestamp
 #> [[1]]$timestamp$created_http
-#> [1] "Sat, 13 Feb 2021 14:24:57 GMT"
+#> [1] "Thu, 18 Feb 2021 19:02:13 GMT"
 #> 
 #> [[1]]$timestamp$created_unix
-#> [1] 1613226297
+#> [1] 1613674933
 #> 
 #> 
 #> [[1]]$total_results
@@ -396,10 +396,10 @@ gjsn_lst
 #> 
 #> $timestamp
 #> $timestamp$created_http
-#> [1] "Sat, 13 Feb 2021 14:24:59 GMT"
+#> [1] "Thu, 18 Feb 2021 19:02:15 GMT"
 #> 
 #> $timestamp$created_unix
-#> [1] 1613226299
+#> [1] 1613674935
 #> 
 #> 
 #> $total_results


### PR DESCRIPTION
From the [CRAN package check results](https://cran.r-project.org/web/checks/check_results_opencage.html) on Solaris:

>    ══ Failed tests ════════════════════════════════════════════════════════════════
     ── Failure (test-oc_config.R:76:3): oc_config updates rate limit of oc_get_limit ──
     `t` is not strictly less than 3. Difference: 5.98

>  Please correct before 2021-03-01 to safely retain your package on CRAN.

This is now fixed with a simpler test, i.e. we just check whether the rates reported by `ratelimitr::get_rates(oc_get_limited)` change.

Until now the CRAN checks have only run on 4 of the 12 platforms. I guess we'd better wait if another one throws an error. 

