### PR TITLE
use `"column"` instead of `.data$column` in select expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * Use [{lintr} version 3.0](https://www.tidyverse.org/blog/2022/07/lintr-3-0-0/) and add "package development" linters ([#144](https://github.com/ropensci/opencage/pull/144)).
 * `countrycodes` source and script were moved to `data-raw` ([#146](https://github.com/ropensci/opencage/pull/146)).
 * Add CITATION.cff and a corresponding GitHub action ([#148](https://github.com/ropensci/opencage/pull/148)).
+* Select expressions inside `oc_forward_df()` and `oc_reverse_df()` now use `"column"` instead of `.data$column`, because the latter is [deprecated as of tidyselect v1.2.0](https://tidyselect.r-lib.org/news/index.html#tidyselect-120)  [#150](https://github.com/ropensci/opencage/pull/150).
 
 # opencage 0.2.2
 

--- a/R/oc_forward.R
+++ b/R/oc_forward.R
@@ -401,18 +401,18 @@ oc_forward_df.data.frame <-
         results <-
           dplyr::select(
             results,
-            .data$oc_query,
-            .data$oc_lat,
-            .data$oc_lng,
-            .data$oc_formatted
+            "oc_query",
+            "oc_lat",
+            "oc_lng",
+            "oc_formatted"
           )
       } else {
         results <-
           dplyr::select(
             results,
-            .data$oc_query,
-            .data$oc_lat,
-            .data$oc_lng,
+            "oc_query",
+            "oc_lat",
+            "oc_lng",
             dplyr::everything()
           )
       }
@@ -440,9 +440,9 @@ oc_forward_df.data.frame <-
 
       if (utils::packageVersion("tidyr") > "0.8.99") {
         results <-
-          tidyr::unnest(results_nest, .data$op, names_repair = "unique")
+          tidyr::unnest(results_nest, "op", names_repair = "unique")
       } else {
-        results <- tidyr::unnest(results_nest, .data$op, .drop = FALSE)
+        results <- tidyr::unnest(results_nest, "op", .drop = FALSE)
         # .drop = FALSE so other list columns are not dropped. Deprecated as of
         # v1.0.0
       }
@@ -451,21 +451,21 @@ oc_forward_df.data.frame <-
         results <-
           dplyr::select(
             results,
-            1:.data$oc_query,
-            .data$oc_lat,
-            .data$oc_lng,
-            .data$oc_formatted,
-            -.data$oc_query
+            1:"oc_query",
+            "oc_lat",
+            "oc_lng",
+            "oc_formatted",
+            -"oc_query"
           )
       } else {
         results <-
           dplyr::select(
             results,
-            1:.data$oc_query,
-            .data$oc_lat,
-            .data$oc_lng,
+            1:"oc_query",
+            "oc_lat",
+            "oc_lng",
             dplyr::everything(),
-            -.data$oc_query
+            -"oc_query"
           )
       }
     }

--- a/R/oc_reverse.R
+++ b/R/oc_reverse.R
@@ -229,10 +229,10 @@ oc_reverse_df.data.frame <-
       results <- dplyr::bind_rows(results_list)
       if (output == "short") {
         results <-
-          dplyr::select(results, .data$oc_query, .data$oc_formatted)
+          dplyr::select(results, "oc_query", "oc_formatted")
       } else {
         results <-
-          dplyr::select(results, .data$oc_query, dplyr::everything())
+          dplyr::select(results, "oc_query", dplyr::everything())
       }
     } else {
       results_nest <-
@@ -255,9 +255,9 @@ oc_reverse_df.data.frame <-
 
       if (utils::packageVersion("tidyr") > "0.8.99") {
         results <-
-          tidyr::unnest(results_nest, .data$op, names_repair = "unique")
+          tidyr::unnest(results_nest, "op", names_repair = "unique")
       } else {
-        results <- tidyr::unnest(results_nest, .data$op, .drop = FALSE)
+        results <- tidyr::unnest(results_nest, "op", .drop = FALSE)
         # .drop = FALSE so other list columns are not dropped. Deprecated as of
         # v1.0.0
       }
@@ -266,17 +266,17 @@ oc_reverse_df.data.frame <-
         results <-
           dplyr::select(
             results,
-            1:.data$oc_query,
-            .data$oc_formatted,
-            -.data$oc_query
+            1:"oc_query",
+            "oc_formatted",
+            -"oc_query"
           )
       } else {
         results <-
           dplyr::select(
             results,
-            1:.data$oc_query,
+            1:"oc_query",
             dplyr::everything(),
-            -.data$oc_query
+            -"oc_query"
           )
       }
     }


### PR DESCRIPTION
Use of `.data` in tidyselect expressions is [deprecated as of tidyselect v1.2.0](https://tidyselect.r-lib.org/news/index.html#tidyselect-120) 


