### PR TITLE
enable coverage on PRs again

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,16 +3,18 @@ on:
   push:
     branches:
       - main
-  # disabled for PRs, because OpenCage key is not available there
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    branches:
+      - main
 
 name: test-coverage
 
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+    # skip for forks as secrets are only available in main repo
+    # keep an eye on https://github.com/orgs/community/discussions/9098
+    if: ${{ github.repository == 'ropensci/opencage' }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 ## Internals
 
 * {opencage} now uses [{testthat} 3e](https://testthat.r-lib.org/articles/third-edition.html) for unit tests ([#141](https://github.com/ropensci/opencage/issues/141)).
-* GitHub actions workflows updated ([#142](https://github.com/ropensci/opencage/issues/142),  [#149](https://github.com/ropensci/opencage/pull/149)).
+* GitHub actions workflows updated ([#142](https://github.com/ropensci/opencage/issues/142),  [#149](https://github.com/ropensci/opencage/pull/149), [#152](https://github.com/ropensci/opencage/pull/152)).
 * Use [{lintr} version 3.0](https://www.tidyverse.org/blog/2022/07/lintr-3-0-0/) and add "package development" linters ([#144](https://github.com/ropensci/opencage/pull/144)).
 * `countrycodes` source and script were moved to `data-raw` ([#146](https://github.com/ropensci/opencage/pull/146)).
 * Add CITATION.cff and a corresponding GitHub action ([#148](https://github.com/ropensci/opencage/pull/148)).


### PR DESCRIPTION
but only on the ropensci repo because that's where the API key is