### PR TITLE
Make tests more robust again

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R: c(
     person("Noam", "Ross", role = "ctb"),
     person("Jake", "Russ", role = "ctb"),
     person("Julia", "Silge", role = "rev",
-           comment = "Julia Silge reviewed {opencage} (v. 0.1.0) for rOpenSci, see <https://github.com/ropensci/onboarding/issues/36>.")
+           comment = "Julia Silge reviewed \\{opencage\\} (v. 0.1.0) for rOpenSci, see <https://github.com/ropensci/onboarding/issues/36>.")
   )
 Description: Geocode with the OpenCage API, either from place name to
     longitude and latitude (forward geocoding) or from longitude and

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,12 +10,14 @@
 ## Internals
 
 * {opencage} now uses [{testthat} 3e](https://testthat.r-lib.org/articles/third-edition.html) for unit tests ([#141](https://github.com/ropensci/opencage/issues/141)).
-* GitHub action workflows have been updated ([#142](https://github.com/ropensci/opencage/issues/142),  [#149](https://github.com/ropensci/opencage/pull/149), [#152](https://github.com/ropensci/opencage/pull/152)), [#164](https://github.com/ropensci/opencage/pull/164)). Styler, document, and rhub workflows have been added ([#153](https://github.com/ropensci/opencage/pull/153), [#164](https://github.com/ropensci/opencage/pull/164)).
 * Use [{lintr} version 3.0](https://www.tidyverse.org/blog/2022/07/lintr-3-0-0/) and add "package development" linters ([#144](https://github.com/ropensci/opencage/pull/144)).
 * `countrycodes` source and script were moved to `data-raw` ([#146](https://github.com/ropensci/opencage/pull/146)).
 * Add CITATION.cff and a corresponding GitHub action ([#148](https://github.com/ropensci/opencage/pull/148)).
 * Select expressions inside `oc_forward_df()` and `oc_reverse_df()` now use `"column"` instead of `.data$column`, because the latter is [deprecated as of tidyselect v1.2.0](https://tidyselect.r-lib.org/news/index.html#tidyselect-120)  ([#150](https://github.com/ropensci/opencage/pull/150)).
 * The opencage code now uses a consistent style (`styler::tidyverse_style()`) and all internal functions are documented  ([#153](https://github.com/ropensci/opencage/pull/153)).
+* GitHub action workflows have been updated ([#142](https://github.com/ropensci/opencage/issues/142),  [#149](https://github.com/ropensci/opencage/pull/149), [#152](https://github.com/ropensci/opencage/pull/152)), [#164](https://github.com/ropensci/opencage/pull/164)). 
+* Styler, document, and rhub GitHub action workflows have been added ([#153](https://github.com/ropensci/opencage/pull/153), [#164](https://github.com/ropensci/opencage/pull/164)).
+* Tests are updated to reflect changes in API responses ([#163](https://github.com/ropensci/opencage/pull/163), [#165](https://github.com/ropensci/opencage/pull/165))
 
 # opencage 0.2.2
 

--- a/man/opencage-package.Rd
+++ b/man/opencage-package.Rd
@@ -30,7 +30,7 @@ Other contributors:
 \itemize{
   \item Noam Ross [contributor]
   \item Jake Russ [contributor]
-  \item Julia Silge (Julia Silge reviewed {opencage} (v. 0.1.0) for rOpenSci, see <https://github.com/ropensci/onboarding/issues/36>.) [reviewer]
+  \item Julia Silge (Julia Silge reviewed \{opencage\} (v. 0.1.0) for rOpenSci, see <https://github.com/ropensci/onboarding/issues/36>.) [reviewer]
 }
 
 }

--- a/tests/testthat/helper-opencage.R
+++ b/tests/testthat/helper-opencage.R
@@ -63,8 +63,8 @@ oc_fw3 <- function() {
 
 ## reverse -----------------------------------------------------------------
 
-oc_lat1 <- function() c(47.21947, 53.55034, 34.05369)
-oc_lng1 <- function() c(-1.54754, 10.000654, -118.242767)
+oc_lat1 <- function() c(52.087106, 53.55034, 34.05369)
+oc_lng1 <- function() c(4.297312, 10.000654, -118.242767)
 
 oc_rev1 <- function() tibble::tibble(id = 1:3, lat = oc_lat1(), lng = oc_lng1())
 

--- a/tests/testthat/test-oc_config.R
+++ b/tests/testthat/test-oc_config.R
@@ -63,6 +63,7 @@ test_that("oc_config updates rate limit of oc_get_limit", {
   expect_identical(ratelimitr::get_rates(oc_get_limited)[[1]][["n"]], rps)
 
   # set rate_sec back to default: 1L/sec
+  withr::local_options(oc_rate_sec = NULL)
   oc_config()
   expect_identical(ratelimitr::get_rates(oc_get_limited)[[1]][["n"]], 1L)
 })

--- a/tests/testthat/test-oc_reverse.R
+++ b/tests/testthat/test-oc_reverse.R
@@ -183,7 +183,7 @@ test_that("tidyeval works for arguments", {
   # language
   lang <-
     oc_reverse_df(oc_rev2(), lat, lng, language = language, output = "all")
-  expect_identical(lang$oc_country, c("France", "Allemagne", "アメリカ合衆国"))
+  expect_identical(lang$oc_country, c("Netherlands", "Allemagne", "アメリカ合衆国"))
 
   # no_annotations
   ann <-


### PR DESCRIPTION
1. use different, hopefully more robust, coordinates for oc_reverse() tests
2. reset `oc_rate_sec` option