### PR TITLE
use knitr::kable() tables in vignettes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * `countrycodes` source and script were moved to `data-raw` ([#146](https://github.com/ropensci/opencage/pull/146)).
 * Add CITATION.cff and a corresponding GitHub action ([#148](https://github.com/ropensci/opencage/pull/148)).
 * Select expressions inside `oc_forward_df()` and `oc_reverse_df()` now use `"column"` instead of `.data$column`, because the latter is [deprecated as of tidyselect v1.2.0](https://tidyselect.r-lib.org/news/index.html#tidyselect-120)  ([#150](https://github.com/ropensci/opencage/pull/150)).
+* Dataframes in the opencage and customise query vignettes are now rendered with the `knitr::kable()` print method ([#166](https://github.com/ropensci/opencage/pull/166)).
 * The opencage code now uses a consistent style (`styler::tidyverse_style()`) and all internal functions are documented  ([#153](https://github.com/ropensci/opencage/pull/153)).
 * GitHub action workflows have been updated ([#142](https://github.com/ropensci/opencage/issues/142),  [#149](https://github.com/ropensci/opencage/pull/149), [#152](https://github.com/ropensci/opencage/pull/152)), [#164](https://github.com/ropensci/opencage/pull/164)). 
 * Styler, document, and rhub GitHub action workflows have been added ([#153](https://github.com/ropensci/opencage/pull/153), [#164](https://github.com/ropensci/opencage/pull/164)).

--- a/vignettes/customise_query.Rmd
+++ b/vignettes/customise_query.Rmd
@@ -1,13 +1,9 @@
 ---
 title: "Customise your query"
 subtitle: "Get more and better results from OpenCage"
-author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
-date: "2024-12-31"
 description: >
   "The OpenCage API supports about a dozen parameters to customise a query and here we will explain how to use them."
-output:
-  rmarkdown::html_vignette:
-    df_print: kable
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Customise your query}
   %\VignetteEngine{knitr::rmarkdown}
@@ -33,20 +29,21 @@ Integer values between 1 and 100 are allowed.
 
 ``` r
 oc_forward_df("Paris")
-#> # A tibble: 1 × 4
-#>   placename oc_lat oc_lng oc_formatted 
-#>   <chr>      <dbl>  <dbl> <chr>        
-#> 1 Paris       48.9   2.32 Paris, France
 ```
+
+|placename |  oc_lat|   oc_lng|oc_formatted  |
+|:---------|-------:|--------:|:-------------|
+|Paris     | 48.8535| 2.348391|Paris, France |
 
 ``` r
 oc_forward_df("Paris", limit = 5)
-#> # A tibble: 2 × 4
-#>   placename oc_lat oc_lng oc_formatted                          
-#>   <chr>      <dbl>  <dbl> <chr>                                 
-#> 1 Paris       48.9   2.35 Paris, France                         
-#> 2 Paris       33.7 -95.6  Paris, Texas, United States of America
 ```
+
+|placename |   oc_lat|     oc_lng|oc_formatted                              |
+|:---------|--------:|----------:|:-----------------------------------------|
+|Paris     | 48.85889|   2.320041|Paris, France                             |
+|Paris     | 33.66180| -95.555513|Paris, Texas, United States of America    |
+|Paris     | 38.20980| -84.252987|Paris, Kentucky, United States of America |
 
 
 Reverse geocoding only returns [at most one result](https://opencagedata.com/api#ranking).
@@ -61,14 +58,15 @@ So, `no_dedupe = TRUE` means that you want duplicates.)
 
 ``` r
 oc_forward_df("Paris", limit = 5, no_dedupe = TRUE)
-#> # A tibble: 4 × 4
-#>   placename oc_lat oc_lng oc_formatted                          
-#>   <chr>      <dbl>  <dbl> <chr>                                 
-#> 1 Paris       48.9   2.35 Paris, France                         
-#> 2 Paris       48.9   2.32 Paris, France                         
-#> 3 Paris       33.7 -95.6  Paris, Texas, United States of America
-#> 4 Paris       48.9   2.32 Paris, France
 ```
+
+|placename |   oc_lat|     oc_lng|oc_formatted                              |
+|:---------|--------:|----------:|:-----------------------------------------|
+|Paris     | 48.85889|   2.320041|Paris, France                             |
+|Paris     | 48.85350|   2.348391|Paris, France                             |
+|Paris     | 33.66180| -95.555513|Paris, Texas, United States of America    |
+|Paris     | 38.20980| -84.252987|Paris, Kentucky, United States of America |
+|Paris     | 48.85889|   2.320041|Paris, France                             |
 
 ## Better targeted results
 
@@ -87,15 +85,15 @@ E.g. "AR" for Argentina, "FR" for France, and "NZ" for the New Zealand.
 
 ``` r
 oc_forward_df(placename = "Paris", countrycode = "US", limit = 5)
-#> # A tibble: 5 × 4
-#>   placename oc_lat oc_lng oc_formatted                              
-#>   <chr>      <dbl>  <dbl> <chr>                                     
-#> 1 Paris       33.7  -95.6 Paris, Texas, United States of America    
-#> 2 Paris       38.2  -84.3 Paris, Kentucky, United States of America 
-#> 3 Paris       36.3  -88.3 Paris, Tennessee, United States of America
-#> 4 Paris       44.2  -70.5 Paris, ME 04281, United States of America 
-#> 5 Paris       35.3  -93.7 Paris, Arkansas, United States of America
 ```
+
+|placename |   oc_lat|    oc_lng|oc_formatted                               |
+|:---------|--------:|---------:|:------------------------------------------|
+|Paris     | 33.66180| -95.55551|Paris, Texas, United States of America     |
+|Paris     | 38.20980| -84.25299|Paris, Kentucky, United States of America  |
+|Paris     | 36.30195| -88.32586|Paris, Tennessee, United States of America |
+|Paris     | 44.26087| -70.50104|Paris, ME 04281, United States of America  |
+|Paris     | 35.29247| -93.72945|Paris, AR 72855, United States of America  |
 
 Multiple countrycodes per `placename` must be wrapped in a list.
 Here is an example with places called "Paris" in Italy and Portugal.
@@ -103,15 +101,15 @@ Here is an example with places called "Paris" in Italy and Portugal.
 
 ``` r
 oc_forward_df(placename = "Paris", countrycode = list(c("IT", "PT")), limit = 5)
-#> # A tibble: 5 × 4
-#>   placename oc_lat oc_lng oc_formatted                                                 
-#>   <chr>      <dbl>  <dbl> <chr>                                                        
-#> 1 Paris       46.5  10.4  23030 Valfurva SO, Italy                                     
-#> 2 Paris       44.6   7.28 Brossasco, Cuneo, Italy                                      
-#> 3 Paris       43.5  12.1  Paris, 52035 Monterchi AR, Italy                             
-#> 4 Paris       37.4  -8.79 Paris, 7630-581 Odemira, Portugal                            
-#> 5 Paris       45.7  13.1  Paris, Via dei Pini 22, 33054 Lignano Sabbiadoro Udine, Italy
 ```
+
+|placename |   oc_lat|    oc_lng|oc_formatted                                        |
+|:---------|--------:|---------:|:---------------------------------------------------|
+|Paris     | 46.46330| 10.419781|23030 Valfurva SO, Italy                            |
+|Paris     | 44.60143|  7.279508|Brossasco, Cuneo, Italy                             |
+|Paris     | 43.46040| 12.081721|Paris, 52035 Monterchi AR, Italy                    |
+|Paris     | 37.44036| -8.788875|Paris, 7630-581 Odemira, Portugal                   |
+|Paris     | 40.47266| 17.241306|Paris, Corso Umberto primo, 74100 Taranto TA, Italy |
 
 Despite the name, country codes also exist for territories that are not independent states, e.g. Gibraltar ("GI"), Greenland ("GL"), Guadaloupe ("GP"), or Guam ("GU").
 You can look up specific country codes with the {[ISOcodes](https://cran.r-project.org/package=ISOcodes)} or {[countrycodes](https://vincentarelbundock.github.io/countrycode/)} packages or on the [ISO](https://www.iso.org/obp/ui/#search/code/) or [Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-1) webpages. In fact, you can also look up country codes via OpenCage as well. If you were interested in the country code of Curaçao for example, you could run:
@@ -119,11 +117,11 @@ You can look up specific country codes with the {[ISOcodes](https://cran.r-proje
 
 ``` r
 oc_forward_df("Curaçao", no_annotations = FALSE)["oc_iso_3166_1_alpha_2"]
-#> # A tibble: 1 × 1
-#>   oc_iso_3166_1_alpha_2
-#>   <chr>                
-#> 1 CW
 ```
+
+|oc_iso_3166_1_alpha_2 |
+|:---------------------|
+|CW                    |
 
 ### `bounds`
 
@@ -137,15 +135,15 @@ Below is an example of the use of `bounds` where the bounding box specifies the 
 
 ``` r
 oc_forward_df(placename = "Paris", bounds = oc_bbox(-97, -56, -32, 12), limit = 5)
-#> # A tibble: 5 × 4
-#>   placename oc_lat oc_lng oc_formatted                                                       
-#>   <chr>      <dbl>  <dbl> <chr>                                                              
-#> 1 Paris       8.05  -80.6 Paris, Distrito de Parita, Panama                                  
-#> 2 Paris      -3.99  -79.2 110107, Loja, Ecuador                                              
-#> 3 Paris      -6.71  -69.9 Eirunepé, Região Geográfica Intermediária de Tefé, Brazil          
-#> 4 Paris     -13.5   -62.5 Canton Motegua, Municipio Baures, Provincia de Iténez, Bolivia     
-#> 5 Paris     -23.5   -47.5 Jardim Santa Fé, Sorocaba, Região Metropolitana de Sorocaba, Brazil
 ```
+
+|placename |     oc_lat|    oc_lng|oc_formatted                                                        |
+|:---------|----------:|---------:|:-------------------------------------------------------------------|
+|Paris     |   8.054226| -80.55320|Paris, Distrito de Parita, Panama                                   |
+|Paris     | -13.518089| -62.48608|Canton Motegua, Municipio Baures, Provincia de Iténez, Bolivia      |
+|Paris     |  -6.710499| -69.89967|Eirunepé, Região Geográfica Intermediária de Tefé, Brazil           |
+|Paris     |  -3.987306| -79.19942|110107, Loja, Ecuador                                               |
+|Paris     | -23.524882| -47.45521|Jardim Santa Fé, Sorocaba, Região Metropolitana de Sorocaba, Brazil |
 
 Again, you can also use {opencage} to determine a bounding box for subsequent queries.
 If you wanted to see how many Plaça d'Espanya there are on the Balearic Islands, for example, you could find the appropriate bounding box and then search for the squares:
@@ -163,28 +161,27 @@ hi_bbox <-
   )
 
 oc_forward_df(placename = "Plaça d'Espanya", bounds = hi_bbox, limit = 20)
-#> # A tibble: 18 × 4
-#>    placename       oc_lat oc_lng oc_formatted                                                   
-#>    <chr>            <dbl>  <dbl> <chr>                                                          
-#>  1 Plaça d'Espanya   39.6   2.65 Plaça d'Espanya, Carrer d'Eusebi Estada, 07003 Palma, Spain    
-#>  2 Plaça d'Espanya   39.6   2.65 Plaça d'Espanya, Canavall, Palma, Balearic Islands, Spain      
-#>  3 Plaça d'Espanya   39.5   2.89 Plaça d'Espanya, 07620 Llucmajor, Spain                        
-#>  4 Plaça d'Espanya   39.0   1.30 Plaça d'Espanya, 07820 Sant Antoni de Portmany, Spain          
-#>  5 Plaça d'Espanya   39.0   1.53 Plaça d'Espanya, Santa Eulària des Riu, Balearic Islands, Spain
-#>  6 Plaça d'Espanya   38.9   1.44 Plaça d'Espanya, 07800 Ibiza, Spain                            
-#>  7 Plaça d'Espanya   39.9   4.27 Plaça d'Espanya, Maó, Spain                                    
-#>  8 Plaça d'Espanya   39.1   1.51 Plaça d'Espanya, Sant Joan de Labritja, Spain                  
-#>  9 Plaça d'Espanya   39.6   2.65 Plaça d'Espanya, 07002 Palma, Spain                            
-#> 10 Plaça d'Espanya   39.8   2.72 Plaça d'Espanya, 07100 Sóller, Spain                           
-#> 11 Plaça d'Espanya   39.6   2.90 Plaça d'Espanya, 07140 Sencelles, Spain                        
-#> 12 Plaça d'Espanya   39.6   2.75 Plaça d'Espanya, 07141 Marratxí, Spain                         
-#> 13 Plaça d'Espanya   39.7   2.91 Plaça d'Espanya, 07300 Inca, Spain                             
-#> 14 Plaça d'Espanya   39.8   2.74 Plaça d'Espanya, 07109 Fornalutx, Spain                        
-#> 15 Plaça d'Espanya   39.5   3.15 Plaça d'Espanya, 07200 Felanitx, Spain                         
-#> 16 Plaça d'Espanya   39.6   2.42 plaça d'Espanya, 07150 Andratx, Spain                          
-#> 17 Plaça d'Espanya   39.5   2.58 Plaça d'Espanya, 07181 Bendinat, Spain                         
-#> 18 Plaça d'Espanya   39.0   1.53 Plaça d'Espanya, 07840 Santa Eulària des Riu, Spain
 ```
+
+|placename       |   oc_lat|   oc_lng|oc_formatted                                                    |
+|:---------------|--------:|--------:|:---------------------------------------------------------------|
+|Plaça d'Espanya | 39.57646| 2.654359|Plaça d'Espanya, Carrer d'Eusebi Estada, 07003 Palma, Spain     |
+|Plaça d'Espanya | 39.57558| 2.653268|Plaça d'Espanya, Canavall, Palma, Balearic Islands, Spain       |
+|Plaça d'Espanya | 39.49070| 2.891332|Plaça d'Espanya, 07620 Llucmajor, Spain                         |
+|Plaça d'Espanya | 38.97986| 1.300523|Plaça d'Espanya, 07820 Sant Antoni de Portmany, Spain           |
+|Plaça d'Espanya | 38.98491| 1.533508|Plaça d'Espanya, Santa Eulària des Riu, Balearic Islands, Spain |
+|Plaça d'Espanya | 39.88877| 4.265172|Plaça d'Espanya, Maó, Spain                                     |
+|Plaça d'Espanya | 38.90699| 1.437946|Plaça d'Espanya, 07800 Ibiza, Spain                             |
+|Plaça d'Espanya | 39.07787| 1.513485|Plaça d'Espanya, Sant Joan de Labritja, Spain                   |
+|Plaça d'Espanya | 39.57494| 2.653829|Plaça d'Espanya, 07002 Palma, Spain                             |
+|Plaça d'Espanya | 39.53399| 2.576478|Plaça d'Espanya, 07181 Calvià, Spain                            |
+|Plaça d'Espanya | 39.64779| 2.897899|Plaça d'Espanya, 07140 Sencelles, Spain                         |
+|Plaça d'Espanya | 39.62170| 2.750391|Plaça d'Espanya, 07141 Marratxí, Spain                          |
+|Plaça d'Espanya | 39.72119| 2.909691|Plaça d'Espanya, 07300 Inca, Spain                              |
+|Plaça d'Espanya | 39.78246| 2.740895|Plaça d'Espanya, 07109 Fornalutx, Spain                         |
+|Plaça d'Espanya | 39.46762| 3.146003|Plaça d'Espanya, 07200 Felanitx, Spain                          |
+|Plaça d'Espanya | 39.57500| 2.420171|plaça d'Espanya, 07150 Andratx, Spain                           |
+|Plaça d'Espanya | 39.76533| 2.715038|Plaça d'Espanya, 07100 Sóller, Spain                            |
 
 Note that OpenCage does not support point-of-interest or feature search, like "show me all bus stops in this area".
 If you are more interested in these kind of features, you might want to take a look at the {[osmdata](https://docs.ropensci.org/osmdata/)} package.
@@ -205,12 +202,12 @@ lx <- oc_forward_df("Lexington, Kentucky")
 lx_point <- oc_points(lx$oc_lat, lx$oc_lng)
 
 oc_forward_df(placename = "Paris", proximity = lx_point, limit = 5)
-#> # A tibble: 2 × 4
-#>   placename oc_lat oc_lng oc_formatted                             
-#>   <chr>      <dbl>  <dbl> <chr>                                    
-#> 1 Paris       38.2 -84.3  Paris, Kentucky, United States of America
-#> 2 Paris       48.9   2.35 Paris, France
 ```
+
+|placename |   oc_lat|    oc_lng|oc_formatted                              |
+|:---------|--------:|---------:|:-----------------------------------------|
+|Paris     | 38.20980| -84.25299|Paris, Kentucky, United States of America |
+|Paris     | 48.85341|   2.34880|Paris, France                             |
 
 Note that the French capital is listed before other places in the US, which are closer to the point provided.
 This illustrates how `proximity` is only one of many factors influencing the ranking of results.
@@ -224,11 +221,11 @@ Thus, in the following example, the French capital is too large to be returned.
 
 ``` r
 oc_forward_df(placename = "Paris", min_confidence = 7, limit = 5)
-#> # A tibble: 1 × 4
-#>   placename oc_lat oc_lng oc_formatted
-#>   <chr>      <dbl>  <dbl> <chr>       
-#> 1 Paris         NA     NA <NA>
 ```
+
+|placename |  oc_lat|    oc_lng|oc_formatted                              |
+|:---------|-------:|---------:|:-----------------------------------------|
+|Paris     | 38.2098| -84.25299|Paris, Kentucky, United States of America |
 
 Note that confidence is not used for the [ranking of results](https://opencagedata.com/api#ranking).
 It does not tell you which result is more "correct" or "relevant", nor what type of thing the result is, but rather how small a result is, geographically speaking.
@@ -246,11 +243,11 @@ OpenCage will attempt to return results in that language.
 
 ``` r
 oc_forward_df(placename = "Munich", language = "tr")
-#> # A tibble: 1 × 4
-#>   placename oc_lat oc_lng oc_formatted           
-#>   <chr>      <dbl>  <dbl> <chr>                  
-#> 1 Munich      48.1   11.6 Münih, Bavyera, Almanya
 ```
+
+|placename |   oc_lat|   oc_lng|oc_formatted            |
+|:---------|--------:|--------:|:-----------------------|
+|Munich    | 48.13711| 11.57538|Münih, Bavyera, Almanya |
 
 Alternatively, you can specify the "native" tag, in which case OpenCage will attempt to return the response in the "official" language(s) of the location.
 Keep in mind, however, that some countries have more than one official language or that the official language may not be the one actually used day-to-day.
@@ -258,22 +255,22 @@ Keep in mind, however, that some countries have more than one official language 
 
 ``` r
 oc_forward_df(placename = "Munich", language = "native")
-#> # A tibble: 1 × 4
-#>   placename oc_lat oc_lng oc_formatted                
-#>   <chr>      <dbl>  <dbl> <chr>                       
-#> 1 Munich      48.1   11.6 München, Bayern, Deutschland
 ```
+
+|placename |   oc_lat|   oc_lng|oc_formatted                 |
+|:---------|--------:|--------:|:----------------------------|
+|Munich    | 48.13711| 11.57538|München, Bayern, Deutschland |
 
 If the `language` parameter is set to `NULL` (which is the default), the tag is not recognized, or OpenCage does not have a record in that language, the results will be returned in English.
 
 
 ``` r
 oc_forward_df(placename = "München")
-#> # A tibble: 1 × 4
-#>   placename oc_lat oc_lng oc_formatted            
-#>   <chr>      <dbl>  <dbl> <chr>                   
-#> 1 München     48.1   11.6 Munich, Bavaria, Germany
 ```
+
+|placename |   oc_lat|   oc_lng|oc_formatted             |
+|:---------|--------:|--------:|:------------------------|
+|München   | 48.13711| 11.57538|Munich, Bavaria, Germany |
 
 To find the correct language tag for your desired language, you can search for the language on the [BCP47 language subtag lookup](https://r12a.github.io/app-subtags/) for example.
 Note however, that there are some language tags in use on OpenStreetMap, one of OpenCage's main sources, that do not conform with the IETF BCP 47 standard.
@@ -336,13 +333,12 @@ Some road and driving information is nevertheless provided as part of the annota
 library(dplyr, warn.conflicts = FALSE)
 oc_forward_df(placename = c("Europa Advance Rd", "Bovoni Rd"), roadinfo = TRUE) |>
 select(placename, contains("roadinfo"))
-#> # A tibble: 2 × 8
-#>   placename         oc_roadinfo_drive_on oc_roadinfo_lanes oc_roadinfo_oneway oc_roadinfo_road    oc_roadinfo_road_type
-#>   <chr>             <chr>                            <int> <chr>              <chr>               <chr>                
-#> 1 Europa Advance Rd right                                1 yes                Europa Advance Road secondary            
-#> 2 Bovoni Rd         left                                NA <NA>               Bovoni Bay Trail    residential          
-#> # ℹ 2 more variables: oc_roadinfo_speed_in <chr>, oc_roadinfo_surface <chr>
 ```
+
+|placename         |oc_roadinfo_drive_on | oc_roadinfo_lanes|oc_roadinfo_oneway |oc_roadinfo_road    |oc_roadinfo_road_type |oc_roadinfo_speed_in |oc_roadinfo_surface |
+|:-----------------|:--------------------|-----------------:|:------------------|:-------------------|:---------------------|:--------------------|:-------------------|
+|Europa Advance Rd |right                |                 1|yes                |Europa Advance Road |secondary             |km/h                 |asphalt             |
+|Bovoni Rd         |left                 |                NA|NA                 |Bovoni Bay Trail    |residential           |mph                  |NA                  |
 
 A [blog post](https://blog.opencagedata.com/post/new-optional-parameter-roadinfo) provides more details.
 
@@ -354,16 +350,19 @@ When it is `TRUE`, the addresses in the `formatted` field of the results are abb
 
 ``` r
 oc_forward_df("Wall Street")
-#> # A tibble: 1 × 4
-#>   placename   oc_lat oc_lng oc_formatted                                             
-#>   <chr>        <dbl>  <dbl> <chr>                                                    
-#> 1 Wall Street   40.7  -74.0 Wall Street, New York, NY 10005, United States of America
-oc_forward_df("Wall Street", abbrv = TRUE)
-#> # A tibble: 1 × 4
-#>   placename   oc_lat oc_lng oc_formatted                    
-#>   <chr>        <dbl>  <dbl> <chr>                           
-#> 1 Wall Street   40.7  -74.0 Wall St, New York, NY 10005, USA
 ```
+
+|placename   |   oc_lat|    oc_lng|oc_formatted                                              |
+|:-----------|--------:|---------:|:---------------------------------------------------------|
+|Wall Street | 40.70766| -74.01152|Wall Street, New York, NY 10005, United States of America |
+
+``` r
+oc_forward_df("Wall Street", abbrv = TRUE)
+```
+
+|placename   |   oc_lat|    oc_lng|oc_formatted                     |
+|:-----------|--------:|---------:|:--------------------------------|
+|Wall Street | 40.70766| -74.01152|Wall St, New York, NY 10005, USA |
 
 See [this blog post](https://blog.opencagedata.com/post/160294347883/shrtr-pls) for more information.
 
@@ -375,16 +374,19 @@ In the following example, the POI "Hôtel de ville de Nantes" (town hall of Nant
 
 ``` r
 oc_reverse_df(47.21947, -1.54754)
-#> # A tibble: 1 × 3
-#>   latitude longitude oc_formatted                                    
-#>      <dbl>     <dbl> <chr>                                           
-#> 1     47.2     -1.55 Le Palais, 37 Rue Gambetta, 44013 Nantes, France
-oc_reverse_df(47.21947, -1.54754, address_only = TRUE)
-#> # A tibble: 1 × 3
-#>   latitude longitude oc_formatted                         
-#>      <dbl>     <dbl> <chr>                                
-#> 1     47.2     -1.55 37 Rue Gambetta, 44013 Nantes, France
 ```
+
+| latitude| longitude|oc_formatted                                     |
+|--------:|---------:|:------------------------------------------------|
+| 47.21947|  -1.54754|Le Palais, 37 Rue Gambetta, 44013 Nantes, France |
+
+``` r
+oc_reverse_df(47.21947, -1.54754, address_only = TRUE)
+```
+
+| latitude| longitude|oc_formatted                          |
+|--------:|---------:|:-------------------------------------|
+| 47.21947|  -1.54754|37 Rue Gambetta, 44013 Nantes, France |
 
 ## Vectorised arguments
 
@@ -396,13 +398,13 @@ oc_forward_df(
   placename = c("New York", "Rio", "Tokyo"),
   language = c("es", "de", "fr")
 )
-#> # A tibble: 3 × 4
-#>   placename oc_lat oc_lng oc_formatted                                                     
-#>   <chr>      <dbl>  <dbl> <chr>                                                            
-#> 1 New York    40.7  -74.0 Nueva York, Estados Unidos de América                            
-#> 2 Rio        -22.9  -43.2 Rio de Janeiro, Região Metropolitana do Rio de Janeiro, Brasilien
-#> 3 Tokyo       35.7  140.  Tokyo, Japon
 ```
+
+|placename |    oc_lat|    oc_lng|oc_formatted                                                      |
+|:---------|---------:|---------:|:-----------------------------------------------------------------|
+|New York  |  40.71273| -74.00602|Nueva York, Estados Unidos de América                             |
+|Rio       | -22.91101| -43.20937|Rio de Janeiro, Região Metropolitana do Rio de Janeiro, Brasilien |
+|Tokyo     |  35.67686| 139.76389|Tokyo, Japon                                                      |
 
 Or geocode place names with country codes in a data frame:
 
@@ -415,13 +417,13 @@ for_df <-
   )
 
 oc_forward_df(for_df, placename = location, countrycode = ccode)
-#> # A tibble: 3 × 5
-#>   location           ccode oc_lat oc_lng oc_formatted                                                                    
-#>   <chr>              <chr>  <dbl>  <dbl> <chr>                                                                           
-#> 1 Golden Gate Bridge at     47.6   15.8  Wiesenbauer, Martin's Golden Gate Bridge, 8684 Steinhaus am Semmering, Austria  
-#> 2 Buckingham Palace  cg     -4.80  11.8  Buckingham Palace, Boulevard du Général Charles de Gaulle, Pointe-Noire, Congo-…
-#> 3 Eiffel Tower       be     50.9    4.34 Eiffel Tower, Avenue de Bouchout - Boechoutlaan, 1020 Brussels, Belgium
 ```
+
+|location           |ccode |    oc_lat|    oc_lng|oc_formatted                                                                               |
+|:------------------|:-----|---------:|---------:|:------------------------------------------------------------------------------------------|
+|Golden Gate Bridge |at    | 47.617126| 15.796731|Wiesenbauer, Martin's Golden Gate Bridge, 8684 Steinhaus am Semmering, Austria             |
+|Buckingham Palace  |cg    | -4.799647| 11.844394|Buckingham Palace, Boulevard du Général Charles de Gaulle, Pointe-Noire, Congo-Brazzaville |
+|Eiffel Tower       |be    | 50.894291|  4.339217|Eiffel Tower, Avenue de Bouchout - Boechoutlaan, 1020 Brussels, Belgium                    |
 
 This also works with `oc_reverse_df()`, of course.
 
@@ -434,12 +436,12 @@ rev_df <-
   )
 
 oc_reverse_df(rev_df, lat, lon, language = "native")
-#> # A tibble: 2 × 3
-#>     lat   lon oc_formatted                                    
-#>   <dbl> <dbl> <chr>                                           
-#> 1  52.4  9.73 Philipsbornstraße 2, 30165 Hannover, Deutschland
-#> 2  41.4  2.13 Carrer de Calatrava, 64, 08017 Barcelona, España
 ```
+
+|      lat|     lon|oc_formatted                                     |
+|--------:|-------:|:------------------------------------------------|
+| 52.38772| 9.73336|Philipsbornstraße 2, 30165 Hannover, Deutschland |
+| 41.40137| 2.12868|Carrer de Calatrava, 64, 08017 Barcelona, España |
 
 ## Further information
 

--- a/vignettes/customise_query.Rmd.src
+++ b/vignettes/customise_query.Rmd.src
@@ -5,9 +5,7 @@ author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
 date: "`r Sys.Date()`"
 description: >
   "The OpenCage API supports about a dozen parameters to customise a query and here we will explain how to use them."
-output:
-  rmarkdown::html_vignette:
-    df_print: kable
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Customise your query}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/customise_query.Rmd.src
+++ b/vignettes/customise_query.Rmd.src
@@ -2,7 +2,6 @@
 title: "Customise your query"
 subtitle: "Get more and better results from OpenCage"
 author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
-date: "`r Sys.Date()`"
 description: >
   "The OpenCage API supports about a dozen parameters to customise a query and here we will explain how to use them."
 output: rmarkdown::html_vignette

--- a/vignettes/customise_query.Rmd.src
+++ b/vignettes/customise_query.Rmd.src
@@ -1,7 +1,6 @@
 ---
 title: "Customise your query"
 subtitle: "Get more and better results from OpenCage"
-author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
 description: >
   "The OpenCage API supports about a dozen parameters to customise a query and here we will explain how to use them."
 output: rmarkdown::html_vignette

--- a/vignettes/opencage.Rmd
+++ b/vignettes/opencage.Rmd
@@ -1,13 +1,9 @@
 ---
 title: "Introduction to opencage"
 subtitle: "Forward and Reverse Geocoding"
-author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
-date: "2024-12-31"
 description: >
   "Get started with the opencage R package to geocode with the OpenCage API, either from place name to longitude and latitude (forward geocoding) or from longitude and latitude to the name and address of a location (reverse geocoding)."
-output:
-  rmarkdown::html_vignette:
-    df_print: kable
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Introduction to opencage}
   %\VignetteEngine{knitr::rmarkdown}
@@ -111,11 +107,11 @@ Now you can start to geocode. Forward geocoding is from location name(s) to lati
 
 ``` r
 oc_forward_df(placename = "Sarzeau")
-#> # A tibble: 1 × 4
-#>   placename oc_lat oc_lng oc_formatted         
-#>   <chr>      <dbl>  <dbl> <chr>                
-#> 1 Sarzeau     47.5  -2.76 56370 Sarzeau, France
 ```
+
+|placename |   oc_lat|  oc_lng|oc_formatted          |
+|:---------|--------:|-------:|:---------------------|
+|Sarzeau   | 47.52877| -2.7642|56370 Sarzeau, France |
 
 All geocoding functions are vectorised, i.e. you can geocode multiple locations with one function call.
 Note that behind the scenes the requests are still sent to the API one-by-one.
@@ -124,13 +120,13 @@ Note that behind the scenes the requests are still sent to the API one-by-one.
 ``` r
 opera <- c("Palacio de Bellas Artes", "Scala", "Sydney Opera House")
 oc_forward_df(placename = opera)
-#> # A tibble: 3 × 4
-#>   placename               oc_lat oc_lng oc_formatted                                                                     
-#>   <chr>                    <dbl>  <dbl> <chr>                                                                            
-#> 1 Palacio de Bellas Artes   19.4  -99.1 Palacio de Bellas Artes, Avenida Juárez, Barrio Chino, 06050 Mexico City, CMX, M…
-#> 2 Scala                     40.7   14.6 84010 Scala SA, Italy                                                            
-#> 3 Sydney Opera House       -33.9  151.  Sydney Opera House, 2 Macquarie Street, Sydney NSW 2000, Australia
 ```
+
+|placename               |    oc_lat|    oc_lng|oc_formatted                                                                          |
+|:-----------------------|---------:|---------:|:-------------------------------------------------------------------------------------|
+|Palacio de Bellas Artes |  19.43563| -99.14122|Palacio de Bellas Artes, Avenida Juárez, Barrio Chino, 06050 Mexico City, CMX, Mexico |
+|Scala                   |  40.65361|  14.60779|84010 Scala SA, Italy                                                                 |
+|Sydney Opera House      | -33.85720| 151.21512|Sydney Opera House, 2 Macquarie Street, Sydney NSW 2000, Australia                    |
 
 By default, `oc_forward_df()` only returns three results columns: `oc_lat` (for latitude), `oc_lon` (for longitude), and  `oc_formatted` (the formatted address).
 As you can see, the results columns are all prefixed with `oc_`.
@@ -140,18 +136,13 @@ Which columns you receive exactly depends on the information OpenCage returns fo
 
 ``` r
 oc_forward_df(placename = opera, output = "all")
-#> # A tibble: 3 × 34
-#>   placename  oc_lat oc_lng oc_confidence oc_formatted oc_northeast_lat oc_northeast_lng oc_southwest_lat oc_southwest_lng
-#>   <chr>       <dbl>  <dbl>         <int> <chr>                   <dbl>            <dbl>            <dbl>            <dbl>
-#> 1 Palacio d…   19.4  -99.1             9 Palacio de …             19.4            -99.1             19.4            -99.1
-#> 2 Scala        40.7   14.6             7 84010 Scala…             40.7             14.6             40.6             14.6
-#> 3 Sydney Op…  -33.9  151.              9 Sydney Oper…            -33.9            151.             -33.9            151. 
-#> # ℹ 25 more variables: oc_iso_3166_1_alpha_2 <chr>, oc_iso_3166_1_alpha_3 <chr>, oc_iso_3166_2 <list>,
-#> #   oc_category <chr>, oc_normalized_city <chr>, oc_type <chr>, oc_borough <chr>, oc_city <chr>, oc_continent <chr>,
-#> #   oc_country <chr>, oc_country_code <chr>, oc_museum <chr>, oc_neighbourhood <chr>, oc_postcode <chr>, oc_road <chr>,
-#> #   oc_state <chr>, oc_state_code <chr>, oc_county <chr>, oc_county_code <chr>, oc_political_union <chr>,
-#> #   oc_village <chr>, oc_attraction <chr>, oc_house_number <chr>, oc_municipality <chr>, oc_suburb <chr>
 ```
+
+|placename               |    oc_lat|    oc_lng| oc_confidence|oc_formatted                                                                          | oc_northeast_lat| oc_northeast_lng| oc_southwest_lat| oc_southwest_lng|oc_iso_3166_1_alpha_2 |oc_iso_3166_1_alpha_3 |oc_iso_3166_2 |oc_category         |oc_normalized_city |oc_type    |oc_borough |oc_city     |oc_continent  |oc_country |oc_country_code |oc_museum               |oc_neighbourhood |oc_postcode |oc_road          |oc_state        |oc_state_code |oc_county |oc_county_code |oc_political_union |oc_village |oc_attraction      |oc_house_number |oc_municipality               |oc_suburb |
+|:-----------------------|---------:|---------:|-------------:|:-------------------------------------------------------------------------------------|----------------:|----------------:|----------------:|----------------:|:---------------------|:---------------------|:-------------|:-------------------|:------------------|:----------|:----------|:-----------|:-------------|:----------|:---------------|:-----------------------|:----------------|:-----------|:----------------|:---------------|:-------------|:---------|:--------------|:------------------|:----------|:------------------|:---------------|:-----------------------------|:---------|
+|Palacio de Bellas Artes |  19.43563| -99.14122|             9|Palacio de Bellas Artes, Avenida Juárez, Barrio Chino, 06050 Mexico City, CMX, Mexico |         19.43598|        -99.14090|         19.43495|        -99.14162|MX                    |MEX                   |MX-CMX        |outdoors/recreation |Mexico City        |museum     |Cuauhtémoc |Mexico City |North America |Mexico     |mx              |Palacio de Bellas Artes |Barrio Chino     |06050       |Avenida Juárez   |Mexico City     |CMX           |NA        |NA             |NA                 |NA         |NA                 |NA              |NA                            |NA        |
+|Scala                   |  40.65361|  14.60779|             7|84010 Scala SA, Italy                                                                 |         40.68811|         14.61181|         40.63577|         14.55518|IT                    |ITA                   |IT-72, IT-SA  |place               |Scala              |village    |NA         |NA          |Europe        |Italy      |it              |NA                      |NA               |84010       |NA               |Campania        |CAM           |Salerno   |SA             |European Union     |Scala      |NA                 |NA              |NA                            |NA        |
+|Sydney Opera House      | -33.85720| 151.21512|             9|Sydney Opera House, 2 Macquarie Street, Sydney NSW 2000, Australia                    |        -33.85630|        151.21589|        -33.85793|        151.21443|AU                    |AUS                   |AU-NSW        |travel/tourism      |Sydney             |attraction |Sydney CBD |Sydney      |Oceania       |Australia  |au              |NA                      |Quay Quarter     |2000        |Macquarie Street |New South Wales |NSW           |NA        |NA             |NA                 |NA         |Sydney Opera House |2               |Council of the City of Sydney |Sydney    |
 
 You can also pass a data frame to `oc_forward_df()`.
 By default the results columns are added to the input data frame, which is useful for keeping information associated with the place names that are in separate columns.
@@ -162,13 +153,13 @@ If you want a data frame with only the geocoding results, set `bind_cols = FALSE
 concert_df <-
   data.frame(location = c("Elbphilharmonie", "Concertgebouw", "Suntory Hall"))
 oc_forward_df(data = concert_df, placename = location)
-#> # A tibble: 3 × 4
-#>   location        oc_lat oc_lng oc_formatted                                                                 
-#>   <chr>            <dbl>  <dbl> <chr>                                                                        
-#> 1 Elbphilharmonie   53.5   9.98 Elbe Philharmonic Hall, Platz der Deutschen Einheit 1, 20457 Hamburg, Germany
-#> 2 Concertgebouw     52.4   4.88 Concertgebouw, Concertgebouwplein 2, 1071 LN Amsterdam, Netherlands          
-#> 3 Suntory Hall      35.7 140.   Suntory Hall, Karayan Plaza, Akasaka 1-chome, Minato, 107-6090, Japan
 ```
+
+|location        |   oc_lat|     oc_lng|oc_formatted                                                                  |
+|:---------------|--------:|----------:|:-----------------------------------------------------------------------------|
+|Elbphilharmonie | 53.54129|   9.984206|Elbe Philharmonic Hall, Platz der Deutschen Einheit 1, 20457 Hamburg, Germany |
+|Concertgebouw   | 52.35620|   4.879045|Concertgebouw, Concertgebouwplein 2, 1071 LN Amsterdam, Netherlands           |
+|Suntory Hall    | 35.66671| 139.741270|Suntory Hall, Karayan Plaza, Akasaka 1-chome, Minato, 107-6090, Japan         |
 
 You can use it in a piped workflow as well.
 
@@ -176,13 +167,13 @@ You can use it in a piped workflow as well.
 ``` r
 library(dplyr, warn.conflicts = FALSE)
 concert_df %>% oc_forward_df(location)
-#> # A tibble: 3 × 4
-#>   location        oc_lat oc_lng oc_formatted                                                                 
-#>   <chr>            <dbl>  <dbl> <chr>                                                                        
-#> 1 Elbphilharmonie   53.5   9.98 Elbe Philharmonic Hall, Platz der Deutschen Einheit 1, 20457 Hamburg, Germany
-#> 2 Concertgebouw     52.4   4.88 Concertgebouw, Concertgebouwplein 2, 1071 LN Amsterdam, Netherlands          
-#> 3 Suntory Hall      35.7 140.   Suntory Hall, Karayan Plaza, Akasaka 1-chome, Minato, 107-6090, Japan
 ```
+
+|location        |   oc_lat|     oc_lng|oc_formatted                                                                  |
+|:---------------|--------:|----------:|:-----------------------------------------------------------------------------|
+|Elbphilharmonie | 53.54129|   9.984206|Elbe Philharmonic Hall, Platz der Deutschen Einheit 1, 20457 Hamburg, Germany |
+|Concertgebouw   | 52.35620|   4.879045|Concertgebouw, Concertgebouwplein 2, 1071 LN Amsterdam, Netherlands           |
+|Suntory Hall    | 35.66671| 139.741270|Suntory Hall, Karayan Plaza, Akasaka 1-chome, Minato, 107-6090, Japan         |
 
 ## Reverse geocoding
 
@@ -191,11 +182,11 @@ Reverse geocoding works in the opposite direction of forward geocoding: from a p
 
 ``` r
 oc_reverse_df(latitude = 51.5034070, longitude = -0.1275920)
-#> # A tibble: 1 × 3
-#>   latitude longitude oc_formatted                                                    
-#>      <dbl>     <dbl> <chr>                                                           
-#> 1     51.5    -0.128 10 Downing Street, Westminster, London, SW1A 2AA, United Kingdom
 ```
+
+| latitude| longitude|oc_formatted                                                     |
+|--------:|---------:|:----------------------------------------------------------------|
+| 51.50341| -0.127592|10 Downing Street, Westminster, London, SW1A 2AA, United Kingdom |
 
 Note that all coordinates sent to the OpenCage API must adhere to the [WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System) (also known as [EPSG:4326](https://epsg.io/4326)) [coordinate reference system](https://en.wikipedia.org/wiki/Spatial_reference_system) in decimal format.
 This is the coordinate reference system used by the [Global Positioning System](https://en.wikipedia.org/wiki/Global_Positioning_System).
@@ -217,11 +208,11 @@ To minimize the number of requests sent to the API {opencage} uses {[memoise](ht
 ``` r
 system.time(oc_reverse(latitude = 10, longitude = 10))
 #>    user  system elapsed 
-#>    0.01    0.00    1.03
+#>    0.00    0.00    0.93
 
 system.time(oc_reverse(latitude = 10, longitude = 10))
 #>    user  system elapsed 
-#>    0.02    0.00    0.02
+#>    0.00    0.00    0.03
 ```
 
 To clear the cache of all results either start a new R session or call `oc_clear_cache()`.
@@ -233,7 +224,7 @@ oc_clear_cache()
 
 system.time(oc_reverse(latitude = 10, longitude = 10))
 #>    user  system elapsed 
-#>    0.01    0.00    1.11
+#>    0.01    0.00    0.76
 ```
 
 As you probably know, cache invalidation is one of the harder things to do in computer science.

--- a/vignettes/opencage.Rmd.src
+++ b/vignettes/opencage.Rmd.src
@@ -1,7 +1,6 @@
 ---
 title: "Introduction to opencage"
 subtitle: "Forward and Reverse Geocoding"
-author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
 description: >
   "Get started with the opencage R package to geocode with the OpenCage API, either from place name to longitude and latitude (forward geocoding) or from longitude and latitude to the name and address of a location (reverse geocoding)."
 output: rmarkdown::html_vignette

--- a/vignettes/opencage.Rmd.src
+++ b/vignettes/opencage.Rmd.src
@@ -2,7 +2,6 @@
 title: "Introduction to opencage"
 subtitle: "Forward and Reverse Geocoding"
 author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
-date: "`r Sys.Date()`"
 description: >
   "Get started with the opencage R package to geocode with the OpenCage API, either from place name to longitude and latitude (forward geocoding) or from longitude and latitude to the name and address of a location (reverse geocoding)."
 output: rmarkdown::html_vignette

--- a/vignettes/opencage.Rmd.src
+++ b/vignettes/opencage.Rmd.src
@@ -5,9 +5,7 @@ author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
 date: "`r Sys.Date()`"
 description: >
   "Get started with the opencage R package to geocode with the OpenCage API, either from place name to longitude and latitude (forward geocoding) or from longitude and latitude to the name and address of a location (reverse geocoding)."
-output:
-  rmarkdown::html_vignette:
-    df_print: kable
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Introduction to opencage}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/output_options.Rmd
+++ b/vignettes/output_options.Rmd
@@ -1,13 +1,9 @@
 ---
 title: "Output options"
 subtitle: "Get different kinds of output from OpenCage"
-author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
-date: "2024-12-31"
 description: >
   "`oc_forward()`/`oc_reverse()` return lists of various type, namely data frames, JSON, GeoJSON or URLs, depending on the `return` value you specify. The possible `return` values are `df_list`, `json_list`, `geojson_list` and `url_only`."
-output:
-  rmarkdown::html_vignette:
-    df_print: kable
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Output options}
   %\VignetteEngine{knitr::rmarkdown}
@@ -188,10 +184,10 @@ oc_forward("Casey Station", return = "json_list")
 #> 
 #> [[1]]$timestamp
 #> [[1]]$timestamp$created_http
-#> [1] "Tue, 31 Dec 2024 10:46:25 GMT"
+#> [1] "Sat, 25 Jan 2025 19:14:52 GMT"
 #> 
 #> [[1]]$timestamp$created_unix
-#> [1] 1735641985
+#> [1] 1737832492
 #> 
 #> 
 #> [[1]]$total_results
@@ -313,10 +309,10 @@ gjsn_lst
 #> 
 #> $timestamp
 #> $timestamp$created_http
-#> [1] "Tue, 31 Dec 2024 10:46:28 GMT"
+#> [1] "Sat, 25 Jan 2025 19:14:54 GMT"
 #> 
 #> $timestamp$created_unix
-#> [1] 1735641988
+#> [1] 1737832494
 #> 
 #> 
 #> $total_results

--- a/vignettes/output_options.Rmd.src
+++ b/vignettes/output_options.Rmd.src
@@ -2,7 +2,6 @@
 title: "Output options"
 subtitle: "Get different kinds of output from OpenCage"
 author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
-date: "`r Sys.Date()`"
 description: >
   "`oc_forward()`/`oc_reverse()` return lists of various type, namely data frames, JSON, GeoJSON or URLs, depending on the `return` value you specify. The possible `return` values are `df_list`, `json_list`, `geojson_list` and `url_only`."
 output: rmarkdown::html_vignette

--- a/vignettes/output_options.Rmd.src
+++ b/vignettes/output_options.Rmd.src
@@ -5,9 +5,7 @@ author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
 date: "`r Sys.Date()`"
 description: >
   "`oc_forward()`/`oc_reverse()` return lists of various type, namely data frames, JSON, GeoJSON or URLs, depending on the `return` value you specify. The possible `return` values are `df_list`, `json_list`, `geojson_list` and `url_only`."
-output:
-  rmarkdown::html_vignette:
-    df_print: kable
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Output options}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/output_options.Rmd.src
+++ b/vignettes/output_options.Rmd.src
@@ -1,7 +1,6 @@
 ---
 title: "Output options"
 subtitle: "Get different kinds of output from OpenCage"
-author: "Daniel Possenriede, Jesse Sadler, Maëlle Salmon"
 description: >
   "`oc_forward()`/`oc_reverse()` return lists of various type, namely data frames, JSON, GeoJSON or URLs, depending on the `return` value you specify. The possible `return` values are `df_list`, `json_list`, `geojson_list` and `url_only`."
 output: rmarkdown::html_vignette

--- a/vignettes/precompile.R
+++ b/vignettes/precompile.R
@@ -8,8 +8,8 @@ library(knitr)
 stopifnot("no OPENCAGE_KEY envvar present" = nzchar(Sys.getenv("OPENCAGE_KEY")))
 
 # write data frames as markdown tables via `knitr::kable()`
-knit_print.data.frame = function(x, ...) {
-  res = paste0(c(kable(x, output = FALSE)), collapse = "\n")
+knit_print.data.frame <- function(x, ...) { # nolint
+  res <- paste0(c(kable(x, output = FALSE)), collapse = "\n")
   asis_output(res)
 }
 # register the method
@@ -20,7 +20,7 @@ knit("vignettes/customise_query.Rmd.src", "vignettes/customise_query.Rmd")
 
 # reset print method for output_options vignette,
 # because kable() doesn't print list columns well
-knit_print.data.frame = function(x, ...) {
+knit_print.data.frame <- function(x, ...) { # nolint
   print(x)
 }
 # register the method

--- a/vignettes/precompile.R
+++ b/vignettes/precompile.R
@@ -1,6 +1,10 @@
-# Precompiled vignettes that depend on API key
+# Pre-compile vignettes that depend on API key
 
-library(knitr) # also load the current version of the package
+pak::local_install() # make sure to use current local version
+
+library(opencage)
+library(knitr)
+
 stopifnot("no OPENCAGE_KEY envvar present" = nzchar(Sys.getenv("OPENCAGE_KEY")))
 
 # write data frames as markdown tables via `knitr::kable()`

--- a/vignettes/precompile.R
+++ b/vignettes/precompile.R
@@ -2,6 +2,24 @@
 
 library(knitr) # also load the current version of the package
 stopifnot("no OPENCAGE_KEY envvar present" = nzchar(Sys.getenv("OPENCAGE_KEY")))
+
+# write data frames as markdown tables via `knitr::kable()`
+knit_print.data.frame = function(x, ...) {
+  res = paste0(c(kable(x, output = FALSE)), collapse = "\n")
+  asis_output(res)
+}
+# register the method
+registerS3method("knit_print", "data.frame", knit_print.data.frame)
+
 knit("vignettes/opencage.Rmd.src", "vignettes/opencage.Rmd")
 knit("vignettes/customise_query.Rmd.src", "vignettes/customise_query.Rmd")
+
+# reset print method for output_options vignette,
+# because kable() doesn't print list columns well
+knit_print.data.frame = function(x, ...) {
+  print(x)
+}
+# register the method
+registerS3method("knit_print", "data.frame", knit_print.data.frame)
+
 knit("vignettes/output_options.Rmd.src", "vignettes/output_options.Rmd")


### PR DESCRIPTION
We now use a knitr::kable() print method in the opencage (intro) and customise query vignettes. This is similar to the `df_print: kable` option usually available for the `html_vignette()` output, but that doesn't work for prerendered vignettes.

This also removes the date and author fields from the vignettes.